### PR TITLE
Add NanoGPT option for benchmarking and pruning

### DIFF
--- a/Deep-CompressionV4/benchmark.py
+++ b/Deep-CompressionV4/benchmark.py
@@ -21,7 +21,7 @@ PRUNING_SCRIPT = os.path.join(PROJECT_ROOT, 'pruning.py')
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Benchmark std vs NeuronRank pruning.')
-    parser.add_argument('--model', choices=['lenet', 'vgg', 'gpt2'], default='lenet',
+    parser.add_argument('--model', choices=['lenet', 'vgg', 'gpt2', 'nanogpt'], default='lenet',
                         help='model to benchmark (default: lenet)')
     parser.add_argument('--vgg-arch', default='vgg19', choices=[
         'vgg11', 'vgg11_bn', 'vgg13', 'vgg13_bn', 'vgg16', 'vgg16_bn', 'vgg19', 'vgg19_bn'
@@ -34,6 +34,17 @@ def parse_args():
                         help='Optional cache directory for GPT-2 checkpoints and WikiText-2')
     parser.add_argument('--gpt2-max-eval-batches', type=int, default=None,
                         help='Limit evaluation batches for GPT-2 benchmarks (useful for smoke tests)')
+    parser.add_argument('--nanogpt-n-layer', type=int, default=6,
+                        help='number of transformer blocks when --model=nanogpt (default: 6)')
+    parser.add_argument('--nanogpt-n-head', type=int, default=6,
+                        help='number of attention heads when --model=nanogpt (default: 6)')
+    parser.add_argument('--nanogpt-n-embd', type=int, default=384,
+                        help='embedding dimension when --model=nanogpt (default: 384)')
+    parser.add_argument('--nanogpt-dropout', type=float, default=0.2,
+                        help='dropout rate when --model=nanogpt (default: 0.2)')
+    parser.add_argument('--nanogpt-no-bias', dest='nanogpt_bias', action='store_false',
+                        help='disable bias terms in NanoGPT layer norms and projections')
+    parser.set_defaults(nanogpt_bias=True)
     parser.add_argument('--device', default=None,
                         help='device argument forwarded to pruning.py (e.g., cuda, mps, cpu)')
     parser.add_argument('--epochs', type=int, nargs='*', default=None,
@@ -67,7 +78,7 @@ def parse_args():
 def default_milestones(model: str):
     if model == 'lenet':
         return [50, 100]
-    if model == 'gpt2':
+    if model in ('gpt2', 'nanogpt'):
         return [1, 2, 3]
     return [50, 100, 150, 200, 250, 300]
 
@@ -294,7 +305,7 @@ def main():
             ]
             if args.model == 'vgg':
                 train_cmd.extend(['--vgg-arch', args.vgg_arch])
-            elif args.model == 'gpt2':
+            elif args.model in ('gpt2', 'nanogpt'):
                 train_cmd.extend([
                     '--gpt2-model-name', args.gpt2_model_name,
                     '--gpt2-block-size', str(args.gpt2_block_size),
@@ -303,6 +314,15 @@ def main():
                     train_cmd.extend(['--gpt2-cache-dir', args.gpt2_cache_dir])
                 if args.gpt2_max_eval_batches is not None:
                     train_cmd.extend(['--gpt2-max-eval-batches', str(args.gpt2_max_eval_batches)])
+                if args.model == 'nanogpt':
+                    train_cmd.extend([
+                        '--nanogpt-n-layer', str(args.nanogpt_n_layer),
+                        '--nanogpt-n-head', str(args.nanogpt_n_head),
+                        '--nanogpt-n-embd', str(args.nanogpt_n_embd),
+                        '--nanogpt-dropout', str(args.nanogpt_dropout),
+                    ])
+                    if not args.nanogpt_bias:
+                        train_cmd.append('--nanogpt-no-bias')
             if args.device:
                 train_cmd.extend(['--device', args.device])
             if args.workers is not None:
@@ -345,7 +365,7 @@ def main():
                     ]
                     if args.model == 'vgg':
                         prune_cmd.extend(['--vgg-arch', args.vgg_arch])
-                    elif args.model == 'gpt2':
+                    elif args.model in ('gpt2', 'nanogpt'):
                         prune_cmd.extend([
                             '--gpt2-model-name', args.gpt2_model_name,
                             '--gpt2-block-size', str(args.gpt2_block_size),
@@ -354,6 +374,15 @@ def main():
                             prune_cmd.extend(['--gpt2-cache-dir', args.gpt2_cache_dir])
                         if args.gpt2_max_eval_batches is not None:
                             prune_cmd.extend(['--gpt2-max-eval-batches', str(args.gpt2_max_eval_batches)])
+                        if args.model == 'nanogpt':
+                            prune_cmd.extend([
+                                '--nanogpt-n-layer', str(args.nanogpt_n_layer),
+                                '--nanogpt-n-head', str(args.nanogpt_n_head),
+                                '--nanogpt-n-embd', str(args.nanogpt_n_embd),
+                                '--nanogpt-dropout', str(args.nanogpt_dropout),
+                            ])
+                            if not args.nanogpt_bias:
+                                prune_cmd.append('--nanogpt-no-bias')
                     if args.device:
                         prune_cmd.extend(['--device', args.device])
                     if args.workers is not None:

--- a/Deep-CompressionV4/gpt/__init__.py
+++ b/Deep-CompressionV4/gpt/__init__.py
@@ -1,6 +1,7 @@
-"""GPT-2 utilities for Deep-Compression."""
+"""Language-model utilities for Deep-Compression."""
 
 from .masked_gpt2 import MaskedGPT2LMHeadModel, apply_masks_to_gpt2
+from .nanogpt import MaskedNanoGPT, NanoGPTConfig
 from .wikitext2 import (  # noqa: F401
     build_wikitext2_dataloaders,
     load_wikitext2,
@@ -9,6 +10,8 @@ from .wikitext2 import (  # noqa: F401
 __all__ = [
     'MaskedGPT2LMHeadModel',
     'apply_masks_to_gpt2',
+    'MaskedNanoGPT',
+    'NanoGPTConfig',
     'load_wikitext2',
     'build_wikitext2_dataloaders',
 ]

--- a/Deep-CompressionV4/gpt/nanogpt.py
+++ b/Deep-CompressionV4/gpt/nanogpt.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from net.prune import MaskedLinear, PruningModule
+
+
+@dataclass
+class NanoGPTConfig:
+    """Configuration for the NanoGPT architecture."""
+
+    vocab_size: int
+    block_size: int
+    n_layer: int = 6
+    n_head: int = 6
+    n_embd: int = 384
+    dropout: float = 0.2
+    bias: bool = True
+
+    def __post_init__(self) -> None:
+        if self.n_embd % self.n_head != 0:
+            raise ValueError('n_embd must be divisible by n_head')
+        if self.block_size <= 0:
+            raise ValueError('block_size must be positive')
+        if self.vocab_size <= 0:
+            raise ValueError('vocab_size must be positive')
+
+
+class CausalSelfAttention(nn.Module):
+    """Multi-head masked self-attention used by NanoGPT."""
+
+    def __init__(self, config: NanoGPTConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.n_head = config.n_head
+        self.n_embd = config.n_embd
+
+        self.c_attn = MaskedLinear(config.n_embd, 3 * config.n_embd, bias=config.bias)
+        self.c_proj = MaskedLinear(config.n_embd, config.n_embd, bias=config.bias)
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.resid_dropout = nn.Dropout(config.dropout)
+
+        mask = torch.tril(torch.ones(config.block_size, config.block_size)).view(
+            1, 1, config.block_size, config.block_size
+        )
+        self.register_buffer('bias', mask, persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, T, C = x.size()
+        qkv = self.c_attn(x)
+        q, k, v = qkv.split(self.n_embd, dim=2)
+
+        # reshape for multi-head attention
+        k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)
+        q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)
+        v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)
+
+        att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+        mask = self.bias[:, :, :T, :T]
+        att = att.masked_fill(mask == 0, float('-inf'))
+        att = F.softmax(att, dim=-1)
+        att = self.attn_dropout(att)
+
+        y = att @ v  # (B, nh, T, hs)
+        y = y.transpose(1, 2).contiguous().view(B, T, C)
+        y = self.resid_dropout(self.c_proj(y))
+        return y
+
+
+class MLP(nn.Module):
+    """Feed-forward network used within a transformer block."""
+
+    def __init__(self, config: NanoGPTConfig) -> None:
+        super().__init__()
+        hidden_dim = 4 * config.n_embd
+        self.c_fc = MaskedLinear(config.n_embd, hidden_dim, bias=config.bias)
+        self.gelu = nn.GELU()
+        self.c_proj = MaskedLinear(hidden_dim, config.n_embd, bias=config.bias)
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.c_fc(x)
+        x = self.gelu(x)
+        x = self.c_proj(x)
+        x = self.dropout(x)
+        return x
+
+
+class Block(nn.Module):
+    """Transformer block."""
+
+    def __init__(self, config: NanoGPTConfig) -> None:
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(config.n_embd, elementwise_affine=config.bias)
+        self.attn = CausalSelfAttention(config)
+        self.ln_2 = nn.LayerNorm(config.n_embd, elementwise_affine=config.bias)
+        self.mlp = MLP(config)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.ln_1(x))
+        x = x + self.mlp(self.ln_2(x))
+        return x
+
+
+class MaskedNanoGPT(PruningModule):
+    """NanoGPT language model with pruning masks on linear projections."""
+
+    def __init__(self, config: NanoGPTConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.token_embedding_table = nn.Embedding(config.vocab_size, config.n_embd)
+        self.position_embedding_table = nn.Embedding(config.block_size, config.n_embd)
+        self.drop = nn.Dropout(config.dropout)
+        self.blocks = nn.ModuleList([Block(config) for _ in range(config.n_layer)])
+        self.ln_f = nn.LayerNorm(config.n_embd, elementwise_affine=config.bias)
+        self.lm_head = MaskedLinear(config.n_embd, config.vocab_size, bias=False)
+
+        self.apply(self._init_weights)
+
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, MaskedLinear):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+            if hasattr(module, 'mask'):
+                module.mask.data.fill_(1.0)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+        elif isinstance(module, nn.LayerNorm):
+            nn.init.ones_(module.weight)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+        **_: torch.Tensor,
+    ) -> SimpleNamespace:
+        B, T = input_ids.size()
+        if T > self.config.block_size:
+            raise ValueError(
+                f'Sequence length {T} exceeds model block size {self.config.block_size}'
+            )
+
+        pos = torch.arange(0, T, dtype=torch.long, device=input_ids.device)
+        tok_emb = self.token_embedding_table(input_ids)
+        pos_emb = self.position_embedding_table(pos)
+        x = tok_emb + pos_emb
+        x = self.drop(x)
+        for block in self.blocks:
+            x = block(x)
+        x = self.ln_f(x)
+        logits = self.lm_head(x)
+
+        loss = None
+        if labels is not None:
+            if attention_mask is not None:
+                # Compute token-level loss then mask out padding positions if provided
+                loss_tensor = F.cross_entropy(
+                    logits.view(-1, logits.size(-1)),
+                    labels.view(-1),
+                    reduction='none',
+                )
+                mask = attention_mask.view(-1).to(loss_tensor.dtype)
+                loss = (loss_tensor * mask).sum() / mask.clamp(min=1.0).sum()
+            else:
+                loss = F.cross_entropy(
+                    logits.view(-1, logits.size(-1)),
+                    labels.view(-1),
+                    reduction='mean',
+                )
+
+        return SimpleNamespace(logits=logits, loss=loss)
+
+
+__all__ = ['NanoGPTConfig', 'MaskedNanoGPT']

--- a/Deep-CompressionV4/pruning.py
+++ b/Deep-CompressionV4/pruning.py
@@ -11,7 +11,12 @@ from torchvision import datasets, transforms
 from tqdm import tqdm
 
 from net.models import LeNet, build_cifar_vgg, SUPPORTED_VGG_ARCHS
-from gpt import MaskedGPT2LMHeadModel, build_wikitext2_dataloaders
+from gpt import (
+    MaskedGPT2LMHeadModel,
+    MaskedNanoGPT,
+    NanoGPTConfig,
+    build_wikitext2_dataloaders,
+)
 import util
 
 
@@ -25,6 +30,7 @@ criterion: Optional[nn.Module] = None
 eval_criterion: Optional[nn.Module] = None
 weight_masks = {}
 non_blocking = False
+tokenizer = None
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +46,7 @@ def build_parser() -> argparse.ArgumentParser:
                         help='full: train + prune (default); train: only fit and save checkpoint; '
                              'prune: load checkpoint and prune/retrain')
 
-    parser.add_argument('--model', choices=['lenet', 'vgg', 'gpt2'], default='lenet',
+    parser.add_argument('--model', choices=['lenet', 'vgg', 'gpt2', 'nanogpt'], default='lenet',
                         help='model to use (default: lenet)')
     parser.add_argument('--vgg-arch', choices=SUPPORTED_VGG_ARCHS, default='vgg19',
                         help='VGG architecture when --model=vgg (default: vgg19)')
@@ -52,6 +58,18 @@ def build_parser() -> argparse.ArgumentParser:
                         help='Optional cache directory for GPT-2 checkpoints and WikiText-2 data')
     parser.add_argument('--gpt2-max-eval-batches', type=int, default=None,
                         help='Limit evaluation batches for GPT-2 runs (useful for smoke tests)')
+
+    parser.add_argument('--nanogpt-n-layer', type=int, default=6,
+                        help='number of transformer blocks when --model=nanogpt (default: 6)')
+    parser.add_argument('--nanogpt-n-head', type=int, default=6,
+                        help='number of attention heads when --model=nanogpt (default: 6)')
+    parser.add_argument('--nanogpt-n-embd', type=int, default=384,
+                        help='embedding dimension when --model=nanogpt (default: 384)')
+    parser.add_argument('--nanogpt-dropout', type=float, default=0.2,
+                        help='dropout rate when --model=nanogpt (default: 0.2)')
+    parser.add_argument('--nanogpt-no-bias', dest='nanogpt_bias', action='store_false',
+                        help='disable bias terms in NanoGPT layer norms and projections')
+    parser.set_defaults(nanogpt_bias=True)
 
     parser.add_argument('--device', choices=['cuda', 'mps', 'cpu'], default=None,
                         help='execution device (auto-detected when omitted)')
@@ -163,7 +181,7 @@ def maybe_log(message: str) -> None:
 def evaluation_metric_key() -> str:
     if args is None:
         return 'accuracy'
-    return 'perplexity' if args.model == 'gpt2' else 'accuracy'
+    return 'perplexity' if args.model in ('gpt2', 'nanogpt') else 'accuracy'
 
 
 def maybe_log_metric(prefix: str, metrics: Dict[str, float]) -> None:
@@ -214,7 +232,7 @@ def ensure_defaults(parsed_args) -> None:
             'weight_decay': 5e-4,
             'workers': 4,
         }
-    else:  # GPT-2 + WikiText-2
+    elif parsed_args.model in ('gpt2', 'nanogpt'):  # Language models + WikiText-2
         defaults = {
             'batch_size': 4,
             'test_batch_size': 4,
@@ -224,13 +242,15 @@ def ensure_defaults(parsed_args) -> None:
             'weight_decay': 0.01,
             'workers': 2,
         }
+    else:
+        raise ValueError(f'Unsupported model: {parsed_args.model}')
     for key, value in defaults.items():
         if getattr(parsed_args, key) is None:
             setattr(parsed_args, key, value)
 
 
 def prepare_environment(parsed_args) -> None:
-    global device, train_loader, test_loader, non_blocking
+    global device, train_loader, test_loader, non_blocking, tokenizer
 
     if parsed_args.device == 'cuda':
         device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
@@ -255,8 +275,8 @@ def prepare_environment(parsed_args) -> None:
     non_blocking = device.type != 'cpu'
     workers = parsed_args.workers or (4 if device.type != 'cpu' else 0)
 
-    if parsed_args.model == 'gpt2':
-        train_loader_local, test_loader_local, _ = build_wikitext2_dataloaders(
+    if parsed_args.model in ('gpt2', 'nanogpt'):
+        train_loader_local, test_loader_local, tok = build_wikitext2_dataloaders(
             tokenizer_name=parsed_args.gpt2_model_name,
             cache_dir=parsed_args.gpt2_cache_dir,
             block_size=parsed_args.gpt2_block_size,
@@ -266,6 +286,7 @@ def prepare_environment(parsed_args) -> None:
             pin_memory=pin_memory,
             shuffle=True,
         )
+        tokenizer = tok
         return train_loader_local, test_loader_local
 
     transform_train, transform_test = None, None
@@ -316,6 +337,27 @@ def instantiate_model(parsed_args) -> Tuple[nn.Module, nn.Module, nn.Module]:
             parsed_args.gpt2_model_name,
             cache_dir=parsed_args.gpt2_cache_dir,
         ).to(device)
+        crit = None
+        eval_crit = None
+    elif parsed_args.model == 'nanogpt':
+        if tokenizer is None:
+            raise RuntimeError('Tokenizer not initialised; call prepare_environment before instantiating NanoGPT')
+        vocab_size = getattr(tokenizer, 'vocab_size', None)
+        if not vocab_size:
+            vocab_size = len(tokenizer)
+        try:
+            config = NanoGPTConfig(
+                vocab_size=int(vocab_size),
+                block_size=parsed_args.gpt2_block_size,
+                n_layer=parsed_args.nanogpt_n_layer,
+                n_head=parsed_args.nanogpt_n_head,
+                n_embd=parsed_args.nanogpt_n_embd,
+                dropout=parsed_args.nanogpt_dropout,
+                bias=parsed_args.nanogpt_bias,
+            )
+        except ValueError as exc:
+            raise ValueError(f'Invalid NanoGPT configuration: {exc}') from exc
+        mdl = MaskedNanoGPT(config).to(device)
         crit = None
         eval_crit = None
     else:
@@ -374,7 +416,7 @@ def build_weight_mask_map(mdl: nn.Module) -> Dict[str, torch.Tensor]:
 def create_optimizer():
     if args.model == 'vgg':
         return optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum, weight_decay=args.weight_decay)
-    if args.model == 'gpt2':
+    if args.model in ('gpt2', 'nanogpt'):
         return torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
     return optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
 
@@ -396,10 +438,12 @@ def train_model(epochs: int, optimizer, mask_grad: bool = False):
         pbar = tqdm(enumerate(train_loader), total=len(train_loader))
         for batch_idx, batch in pbar:
             optimizer.zero_grad()
-            if args.model == 'gpt2':
+            if args.model in ('gpt2', 'nanogpt'):
                 inputs = {k: v.to(device, non_blocking=non_blocking) for k, v in batch.items()}
                 outputs = model(**inputs)
                 loss = outputs.loss
+                if loss is None:
+                    raise RuntimeError('Language model forward pass did not return a loss value')
             else:
                 data, target = batch
                 data = data.to(device, non_blocking=non_blocking)
@@ -419,7 +463,7 @@ def train_model(epochs: int, optimizer, mask_grad: bool = False):
             optimizer.step()
             
             # Update progress bar description every batch for better visibility
-            if args.model == 'gpt2':
+            if args.model in ('gpt2', 'nanogpt'):
                 # Calculate actual samples processed (handle variable batch sizes correctly)
                 current_batch_size = inputs['input_ids'].size(0)
                 done = batch_idx * args.batch_size + current_batch_size
@@ -440,7 +484,7 @@ def train_model(epochs: int, optimizer, mask_grad: bool = False):
 
 def evaluate_model() -> Dict[str, float]:
     model.eval()
-    if args.model == 'gpt2':
+    if args.model in ('gpt2', 'nanogpt'):
         total_loss = 0.0
         total_tokens = 0
         examples = 0
@@ -449,7 +493,13 @@ def evaluate_model() -> Dict[str, float]:
                 inputs = {k: v.to(device, non_blocking=non_blocking) for k, v in batch.items()}
                 outputs = model(**inputs)
                 loss = outputs.loss
-                token_count = inputs['input_ids'].numel()
+                if loss is None:
+                    raise RuntimeError('Language model forward pass did not return a loss value')
+                attention = inputs.get('attention_mask')
+                if attention is not None:
+                    token_count = int(attention.sum().item())
+                else:
+                    token_count = inputs['input_ids'].numel()
                 total_loss += loss.item() * token_count
                 total_tokens += token_count
                 examples += inputs['input_ids'].size(0)
@@ -482,7 +532,7 @@ def collect_activation_statistics(mdl: nn.Module, data_loader, activation_thresh
     stats: Dict[str, Dict[str, torch.Tensor]] = {}
     handles = []
 
-    is_gpt2 = args.model == 'gpt2'
+    is_language_model = args.model in ('gpt2', 'nanogpt')
 
     for name, module in mdl.named_modules():
         if not hasattr(module, 'mask'):
@@ -496,7 +546,7 @@ def collect_activation_statistics(mdl: nn.Module, data_loader, activation_thresh
                 if features is None:
                     return
                 features = features.detach()
-                if is_gpt2 and features.dim() >= 3:
+                if is_language_model and features.dim() >= 3:
                     flattened = features.abs().mean(dim=1)
                 elif features.dim() > 2:
                     reduce_dims = tuple(range(2, features.dim()))
@@ -532,7 +582,7 @@ def collect_activation_statistics(mdl: nn.Module, data_loader, activation_thresh
         for batch_idx, batch in enumerate(data_loader):
             if max_batches is not None and batch_idx >= max_batches:
                 break
-            if is_gpt2:
+            if is_language_model:
                 inputs = {
                     key: value.to(device, non_blocking=non_blocking)
                     for key, value in batch.items()


### PR DESCRIPTION
## Summary
- add a masked NanoGPT implementation that exposes pruning masks on attention and MLP projections
- extend pruning and benchmark entry points with a `--model nanogpt` option plus configuration flags for the new architecture
- update training, evaluation, and activation-stat collection paths to treat GPT-2 and NanoGPT consistently when using WikiText-2

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf872b82748321bba4fa2980e9367d