### PR TITLE
Ensure masked linear weights zeroed after pruning

### DIFF
--- a/Deep-CompressionV4/net/prune.py
+++ b/Deep-CompressionV4/net/prune.py
@@ -282,5 +282,6 @@ class MaskedLinear(Module):
 
     def apply_new_mask(self, new_mask):
         new_mask = new_mask.to(self.mask.device, dtype=self.mask.dtype)
-        self.mask.data = new_mask
+        self.mask.data.copy_(new_mask)
+        self.weight.data.mul_(self.mask.data)
 


### PR DESCRIPTION
## Summary
- update MaskedLinear.apply_new_mask to copy the provided mask tensor and immediately zero masked weights

## Testing
- python - <<'PY'
import os
import sys
sys.path.insert(0, os.path.abspath('Deep-CompressionV4'))

import torch
from gpt.nanogpt import MaskedNanoGPT, NanoGPTConfig
import util

config = NanoGPTConfig(vocab_size=32, block_size=16, n_layer=1, n_head=1, n_embd=16, dropout=0.0, bias=True)
model = MaskedNanoGPT(config)

initial_stats = util.collect_nonzero_stats(model)
print('Initial stats:', initial_stats)

model.prune_by_percentile(50.0)

post_stats = util.collect_nonzero_stats(model)
print('Post-prune stats:', post_stats)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cf8dac10608321b9b4857d79abe17a