### PR TITLE
Handle missing datasets dependency for WikiText-2

### DIFF
--- a/Deep-CompressionV4/gpt/__init__.py
+++ b/Deep-CompressionV4/gpt/__init__.py
@@ -2,10 +2,25 @@
 
 from .masked_gpt2 import MaskedGPT2LMHeadModel, apply_masks_to_gpt2
 from .nanogpt import MaskedNanoGPT, NanoGPTConfig
-from .wikitext2 import (  # noqa: F401
-    build_wikitext2_dataloaders,
-    load_wikitext2,
-)
+try:
+    from .wikitext2 import (  # noqa: F401
+        build_wikitext2_dataloaders,
+        load_wikitext2,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    _missing_dependency = exc.name or 'datasets'
+
+    def _missing_wikitext2(*_args, **_kwargs):
+        raise ModuleNotFoundError(
+            "Optional dependency '{dep}' is required for WikiText-2 utilities. "
+            "Install it with `pip install {dep}` or install the 'datasets' and "
+            "'transformers' packages to enable GPT-2 workflows.".format(
+                dep=_missing_dependency
+            )
+        ) from exc
+
+    build_wikitext2_dataloaders = _missing_wikitext2
+    load_wikitext2 = _missing_wikitext2
 
 __all__ = [
     'MaskedGPT2LMHeadModel',


### PR DESCRIPTION
## Summary
- avoid import-time failures when optional WikiText-2 dependencies are missing
- raise a helpful ModuleNotFoundError only if the GPT-2 data loaders are actually invoked

## Testing
- python -m compileall gpt/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb1db97b08321996e5fcac0409ef2