### PR TITLE
Fix optional WikiText loader exception handling

### DIFF
--- a/Deep-CompressionV4/gpt/__init__.py
+++ b/Deep-CompressionV4/gpt/__init__.py
@@ -9,6 +9,7 @@ try:
     )
 except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
     _missing_dependency = exc.name or 'datasets'
+    _missing_exception = exc
 
     def _missing_wikitext2(*_args, **_kwargs):
         raise ModuleNotFoundError(
@@ -17,7 +18,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
             "'transformers' packages to enable GPT-2 workflows.".format(
                 dep=_missing_dependency
             )
-        ) from exc
+        ) from _missing_exception
 
     build_wikitext2_dataloaders = _missing_wikitext2
     load_wikitext2 = _missing_wikitext2


### PR DESCRIPTION
## Summary
- preserve the original ModuleNotFoundError when raising the WikiText-2 helper

## Testing
- python -m compileall gpt/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb37505988321be96f68b7c7ba01b