### PR TITLE
Add masked SqueezeNet support

### DIFF
--- a/Deep-CompressionV4/README.md
+++ b/Deep-CompressionV4/README.md
@@ -80,6 +80,30 @@ Outputs are written to `benchmark_outputs/` (configurable via `--output-dir`) an
 include a JSONL file with raw metrics, a CSV export, and PNG plots showing
 accuracy vs. compression for each epoch milestone.
 
+### SqueezeNet + CIFAR-10
+
+SqueezeNet plugs into the same CIFAR-10 pipeline as VGG. Install the dependencies listed
+above (or via pip):
+
+```bash
+pip install torch torchvision tqdm numpy matplotlib
+```
+
+Run a one-shot prune using the baked-in CIFAR-10 defaults (SGD + momentum, augmentation, etc.):
+
+```bash
+python pruning.py --model squeezenet --mode full --epochs 100 --target-sparsity 0.9
+```
+
+To sweep sparsities and seeds automatically:
+
+```bash
+python benchmark.py --model squeezenet --epochs 50 100 --device cuda
+```
+
+The benchmark helper forwards additional arguments (e.g. `--pruning-args`) to `pruning.py` so you
+can reuse NeuronRank tuning without rewriting commands.
+
 ### GPT-2 + NeuronRank on WikiText-2
 
 Phase 1-3 add a full GPT-2 pipeline: fine-tuning, pruning, and benchmarking.

--- a/Deep-CompressionV4/benchmark.py
+++ b/Deep-CompressionV4/benchmark.py
@@ -21,11 +21,13 @@ PRUNING_SCRIPT = os.path.join(PROJECT_ROOT, 'pruning.py')
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Benchmark std vs NeuronRank pruning.')
-    parser.add_argument('--model', choices=['lenet', 'vgg', 'gpt2', 'nanogpt'], default='lenet',
+    parser.add_argument('--model', choices=['lenet', 'vgg', 'squeezenet', 'gpt2', 'nanogpt'], default='lenet',
                         help='model to benchmark (default: lenet)')
     parser.add_argument('--vgg-arch', default='vgg19', choices=[
         'vgg11', 'vgg11_bn', 'vgg13', 'vgg13_bn', 'vgg16', 'vgg16_bn', 'vgg19', 'vgg19_bn'
     ], help='VGG architecture when benchmarking VGG (default: vgg19)')
+    parser.add_argument('--squeezenet-version', default='1.1', choices=['1.1'],
+                        help='SqueezeNet version when benchmarking (default: 1.1)')
     parser.add_argument('--gpt2-model-name', default='gpt2',
                         help='Hugging Face model identifier or local path when benchmarking GPT-2')
     parser.add_argument('--gpt2-block-size', type=int, default=1024,
@@ -85,6 +87,8 @@ def parse_args():
 
 def default_milestones(model: str):
     if model == 'lenet':
+        return [50, 100]
+    if model == 'squeezenet':
         return [50, 100]
     if model in ('gpt2', 'nanogpt'):
         return [1, 2, 3]
@@ -317,6 +321,8 @@ def main():
             ]
             if args.model == 'vgg':
                 train_cmd.extend(['--vgg-arch', args.vgg_arch])
+            elif args.model == 'squeezenet':
+                train_cmd.extend(['--squeezenet-version', args.squeezenet_version])
             elif args.model in ('gpt2', 'nanogpt'):
                 train_cmd.extend([
                     '--gpt2-model-name', args.gpt2_model_name,
@@ -380,6 +386,8 @@ def main():
                     ]
                     if args.model == 'vgg':
                         prune_cmd.extend(['--vgg-arch', args.vgg_arch])
+                    elif args.model == 'squeezenet':
+                        prune_cmd.extend(['--squeezenet-version', args.squeezenet_version])
                     elif args.model in ('gpt2', 'nanogpt'):
                         prune_cmd.extend([
                             '--gpt2-model-name', args.gpt2_model_name,

--- a/Deep-CompressionV4/net/models.py
+++ b/Deep-CompressionV4/net/models.py
@@ -173,3 +173,106 @@ def build_cifar_vgg(arch='vgg19', mask=False, num_classes=10, init_weights=True)
 
     features = _make_vgg_layers(_VGG_CONFIGS[cfg_key], batch_norm=batch_norm, mask=mask)
     return CifarVGG(features, num_classes=num_classes, init_weights=init_weights, mask=mask)
+
+
+class Fire(nn.Module):
+    """SqueezeNet Fire module with optional pruning masks."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        squeeze_channels: int,
+        expand1x1_channels: int,
+        expand3x3_channels: int,
+        *,
+        mask: bool = False,
+    ) -> None:
+        super().__init__()
+        conv_cls = MaskedConv2d if mask else nn.Conv2d
+
+        self.squeeze = conv_cls(in_channels, squeeze_channels, kernel_size=1)
+        self.squeeze_activation = nn.ReLU(inplace=True)
+
+        self.expand1x1 = conv_cls(squeeze_channels, expand1x1_channels, kernel_size=1)
+        self.expand1x1_activation = nn.ReLU(inplace=True)
+
+        self.expand3x3 = conv_cls(squeeze_channels, expand3x3_channels, kernel_size=3, padding=1)
+        self.expand3x3_activation = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.squeeze_activation(self.squeeze(x))
+        return torch.cat([
+            self.expand1x1_activation(self.expand1x1(x)),
+            self.expand3x3_activation(self.expand3x3(x)),
+        ], dim=1)
+
+
+class MaskedSqueezeNet(PruningModule):
+    """Masked SqueezeNet backbone tuned for CIFAR-10."""
+
+    def __init__(self, num_classes: int = 10, *, mask: bool = False, init_weights: bool = True) -> None:
+        super().__init__()
+        conv_cls = MaskedConv2d if mask else nn.Conv2d
+
+        self.features = nn.Sequential(
+            conv_cls(3, 64, kernel_size=3, stride=1, padding=1),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=2, stride=2, ceil_mode=True),
+            Fire(64, 16, 64, 64, mask=mask),
+            Fire(128, 16, 64, 64, mask=mask),
+            nn.MaxPool2d(kernel_size=2, stride=2, ceil_mode=True),
+            Fire(128, 32, 128, 128, mask=mask),
+            Fire(256, 32, 128, 128, mask=mask),
+            nn.MaxPool2d(kernel_size=2, stride=2, ceil_mode=True),
+            Fire(256, 48, 192, 192, mask=mask),
+            Fire(384, 48, 192, 192, mask=mask),
+            Fire(384, 64, 256, 256, mask=mask),
+            Fire(512, 64, 256, 256, mask=mask),
+        )
+
+        self.classifier = nn.Sequential(
+            nn.Dropout(p=0.5),
+            conv_cls(512, num_classes, kernel_size=1),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d((1, 1)),
+        )
+
+        if init_weights:
+            self._initialize_weights()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = self.classifier(x)
+        return torch.flatten(x, 1)
+
+    def _initialize_weights(self) -> None:
+        for module in self.modules():
+            if isinstance(module, (nn.Conv2d, MaskedConv2d)):
+                if module is self.classifier[1]:
+                    nn.init.normal_(module.weight, mean=0.0, std=0.01)
+                else:
+                    nn.init.kaiming_uniform_(module.weight, a=math.sqrt(5))
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+
+
+def build_cifar_squeezenet(version: str = '1.1', *, mask: bool = False, num_classes: int = 10, init_weights: bool = True) -> MaskedSqueezeNet:
+    """Instantiate a masked SqueezeNet variant configured for CIFAR-10."""
+
+    if version != '1.1':
+        raise ValueError(f"Unsupported SqueezeNet version '{version}'. Only '1.1' is available.")
+
+    return MaskedSqueezeNet(num_classes=num_classes, mask=mask, init_weights=init_weights)
+
+
+__all__ = [
+    'LeNet',
+    'LeNet_5',
+    'MaskedConv2d',
+    'MaskedSqueezeNet',
+    'Fire',
+    'SUPPORTED_VGG_ARCHS',
+    'CifarVGG',
+    'build_cifar_vgg',
+    'build_cifar_squeezenet',
+]

--- a/Deep-CompressionV4/pruning.py
+++ b/Deep-CompressionV4/pruning.py
@@ -12,7 +12,7 @@ import torch.optim as optim
 from torchvision import datasets, transforms
 from tqdm import tqdm
 
-from net.models import LeNet, build_cifar_vgg, SUPPORTED_VGG_ARCHS
+from net.models import LeNet, build_cifar_vgg, build_cifar_squeezenet, SUPPORTED_VGG_ARCHS
 from gpt import (
     MaskedGPT2LMHeadModel,
     MaskedNanoGPT,
@@ -48,10 +48,12 @@ def build_parser() -> argparse.ArgumentParser:
                         help='full: train + prune (default); train: only fit and save checkpoint; '
                              'prune: load checkpoint and prune/retrain')
 
-    parser.add_argument('--model', choices=['lenet', 'vgg', 'gpt2', 'nanogpt'], default='lenet',
+    parser.add_argument('--model', choices=['lenet', 'vgg', 'squeezenet', 'gpt2', 'nanogpt'], default='lenet',
                         help='model to use (default: lenet)')
     parser.add_argument('--vgg-arch', choices=SUPPORTED_VGG_ARCHS, default='vgg19',
                         help='VGG architecture when --model=vgg (default: vgg19)')
+    parser.add_argument('--squeezenet-version', choices=['1.1'], default='1.1',
+                        help='SqueezeNet version when --model=squeezenet (default: 1.1)')
     parser.add_argument('--gpt2-model-name', type=str, default='gpt2',
                         help='Hugging Face model identifier or local path when --model=gpt2')
     parser.add_argument('--gpt2-block-size', type=int, default=1024,
@@ -224,7 +226,7 @@ def ensure_defaults(parsed_args) -> None:
             'weight_decay': 0.0001,
             'workers': 2,
         }
-    elif parsed_args.model == 'vgg':  # VGG + CIFAR-10
+    elif parsed_args.model in ('vgg', 'squeezenet'):  # CIFAR-10 convolutional models
         defaults = {
             'batch_size': 128,
             'test_batch_size': 128,
@@ -300,7 +302,7 @@ def prepare_environment(parsed_args) -> None:
         return train_loader_local, test_loader_local
 
     transform_train, transform_test = None, None
-    if parsed_args.model == 'vgg':
+    if parsed_args.model in ('vgg', 'squeezenet'):
         transform_train = transforms.Compose([
             transforms.RandomHorizontalFlip(),
             transforms.RandomCrop(32, padding=4),
@@ -340,6 +342,14 @@ def prepare_environment(parsed_args) -> None:
 def instantiate_model(parsed_args) -> Tuple[nn.Module, nn.Module, nn.Module]:
     if parsed_args.model == 'vgg':
         mdl = build_cifar_vgg(parsed_args.vgg_arch, mask=True, num_classes=10).to(device)
+        crit = nn.CrossEntropyLoss().to(device)
+        eval_crit = nn.CrossEntropyLoss(reduction='sum').to(device)
+    elif parsed_args.model == 'squeezenet':
+        mdl = build_cifar_squeezenet(
+            parsed_args.squeezenet_version,
+            mask=True,
+            num_classes=10,
+        ).to(device)
         crit = nn.CrossEntropyLoss().to(device)
         eval_crit = nn.CrossEntropyLoss(reduction='sum').to(device)
     elif parsed_args.model == 'gpt2':
@@ -384,6 +394,7 @@ def save_checkpoint(path: Optional[str], train_epochs: int) -> None:
     payload = {
         'model': args.model,
         'vgg_arch': args.vgg_arch if args.model == 'vgg' else None,
+        'squeezenet_version': args.squeezenet_version if args.model == 'squeezenet' else None,
         'state_dict': model.state_dict(),
         'metadata': {
             'train_epochs': train_epochs,
@@ -408,6 +419,8 @@ def load_checkpoint(path: str) -> Dict:
         args.model = checkpoint['model']
     if checkpoint.get('vgg_arch'):
         args.vgg_arch = checkpoint['vgg_arch']
+    if checkpoint.get('squeezenet_version'):
+        args.squeezenet_version = checkpoint['squeezenet_version']
     return checkpoint
 
 
@@ -424,7 +437,7 @@ def build_weight_mask_map(mdl: nn.Module) -> Dict[str, torch.Tensor]:
 
 
 def create_optimizer():
-    if args.model == 'vgg':
+    if args.model in ('vgg', 'squeezenet'):
         return optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum, weight_decay=args.weight_decay)
     if args.model in ('gpt2', 'nanogpt'):
         return torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
@@ -432,7 +445,7 @@ def create_optimizer():
 
 
 def adjust_learning_rate(optimizer, epoch, base_lr):
-    if args.model != 'vgg':
+    if args.model not in ('vgg', 'squeezenet'):
         return
     lr = base_lr * (0.5 ** (epoch // 30))
     for param_group in optimizer.param_groups:


### PR DESCRIPTION
## Summary
- add a masked SqueezeNet CIFAR-10 backbone that exposes masks on every convolution and export it for pruning
- extend pruning and benchmark CLIs with SqueezeNet defaults plus SGD handling so CIFAR-10 runs reuse existing workflows
- document the new SqueezeNet usage pattern alongside CIFAR-10 presets

## Testing
- python -m compileall net pruning.py benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c45e3cbc83218c9ae77aeece8f62