### PR TITLE
Adjust MaskedSqueezeNet convolution initialization

### DIFF
--- a/Deep-CompressionV4/net/models.py
+++ b/Deep-CompressionV4/net/models.py
@@ -251,7 +251,9 @@ class MaskedSqueezeNet(PruningModule):
                 if module is self.classifier[1]:
                     nn.init.normal_(module.weight, mean=0.0, std=0.01)
                 else:
-                    nn.init.kaiming_uniform_(module.weight, a=math.sqrt(5))
+                    nn.init.kaiming_uniform_(
+                        module.weight, mode='fan_out', nonlinearity='relu'
+                    )
                 if module.bias is not None:
                     nn.init.constant_(module.bias, 0)
 


### PR DESCRIPTION
## Summary
- switch MaskedSqueezeNet convolution layers to use `kaiming_uniform_` with `fan_out`/ReLU defaults
- retain the classifier head's normal initialization and zero bias handling

## Testing
- python -m compileall net pruning.py

------
https://chatgpt.com/codex/tasks/task_e_68d1d17c38688321808b164e5f37933a