### PR TITLE
Add embedding masks for NanoGPT pruning

### DIFF
--- a/Deep-CompressionV4/gpt/nanogpt.py
+++ b/Deep-CompressionV4/gpt/nanogpt.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from net.prune import MaskedLinear, PruningModule
+from net.prune import MaskedEmbedding, MaskedLinear, PruningModule
 
 
 @dataclass
@@ -115,8 +115,8 @@ class MaskedNanoGPT(PruningModule):
     def __init__(self, config: NanoGPTConfig) -> None:
         super().__init__()
         self.config = config
-        self.token_embedding_table = nn.Embedding(config.vocab_size, config.n_embd)
-        self.position_embedding_table = nn.Embedding(config.block_size, config.n_embd)
+        self.token_embedding_table = MaskedEmbedding(config.vocab_size, config.n_embd)
+        self.position_embedding_table = MaskedEmbedding(config.block_size, config.n_embd)
         self.drop = nn.Dropout(config.dropout)
         self.blocks = nn.ModuleList([Block(config) for _ in range(config.n_layer)])
         self.ln_f = nn.LayerNorm(config.n_embd, elementwise_affine=config.bias)

--- a/Deep-CompressionV4/net/prune.py
+++ b/Deep-CompressionV4/net/prune.py
@@ -656,6 +656,63 @@ class MaskedLinear(Module):
         self.weight.data.mul_(self.mask.data)
 
 
+class MaskedEmbedding(nn.Embedding):
+    """Embedding layer equipped with a pruning mask."""
+
+    def __init__(self, num_embeddings: int, embedding_dim: int, **kwargs) -> None:
+        super().__init__(num_embeddings, embedding_dim, **kwargs)
+        mask = torch.ones_like(self.weight)
+        self.mask = Parameter(mask, requires_grad=False)
+
+    def forward(self, input):
+        masked_weight = self.weight * self.mask
+        return F.embedding(
+            input,
+            masked_weight,
+            self.padding_idx,
+            self.max_norm,
+            self.norm_type,
+            self.scale_grad_by_freq,
+            self.sparse,
+        )
+
+    def prune(self, threshold):
+        with torch.no_grad():
+            threshold_tensor = torch.as_tensor(
+                threshold,
+                dtype=self.weight.dtype,
+                device=self.weight.device,
+            )
+            zero_mask = torch.zeros_like(self.mask)
+            new_mask = torch.where(
+                self.weight.abs() < threshold_tensor,
+                zero_mask,
+                self.mask,
+            )
+            self.apply_new_mask(new_mask)
+
+    def prune_with_scores(self, scores, threshold):
+        with torch.no_grad():
+            score_tensor = scores.to(self.weight.device, dtype=self.weight.dtype)
+            threshold_tensor = torch.as_tensor(
+                threshold,
+                dtype=score_tensor.dtype,
+                device=score_tensor.device,
+            )
+            zero_mask = torch.zeros_like(self.mask)
+            new_mask = torch.where(
+                (score_tensor < threshold_tensor) & (self.mask > 0),
+                zero_mask,
+                self.mask,
+            )
+            self.apply_new_mask(new_mask)
+
+    def apply_new_mask(self, new_mask):
+        new_mask = new_mask.to(dtype=self.mask.dtype, device=self.mask.device)
+        self.mask.data.copy_(new_mask)
+        self.weight.data.mul_(self.mask.data)
+
+
 @dataclass
 class NeuronPruningGroup:
     """Represents a coupled pair of linear layers sharing a hidden neuron."""

--- a/Deep-CompressionV4/pruning.py
+++ b/Deep-CompressionV4/pruning.py
@@ -696,10 +696,12 @@ def collect_activation_statistics(
             continue
 
         def make_hook(layer_name):
-            def hook(_module, inputs, _output):
-                if not inputs:
-                    return
-                features = inputs[0]
+            def hook(module_ref, inputs, output):
+                features = None
+                if isinstance(module_ref, nn.Embedding):
+                    features = output
+                elif inputs:
+                    features = inputs[0]
                 if features is None:
                     return
 


### PR DESCRIPTION
## Summary
- add a reusable `MaskedEmbedding` layer so embedding tables participate in pruning
- update `MaskedNanoGPT` to use masked embeddings for token and positional tables
- adjust activation-statistics hooks to read embedding activations from their outputs, allowing NeuronRank to score them

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2dbc75e08832196217d6715a5ab11