### PR TITLE
Ensure pruned weights stay zero during retraining

### DIFF
--- a/Deep-CompressionV4/pruning.py
+++ b/Deep-CompressionV4/pruning.py
@@ -918,6 +918,19 @@ def train_model(
 
             optimizer.step()
 
+            if mask_grad and weight_masks:
+                for name, param in model.named_parameters():
+                    mask = weight_masks.get(name)
+                    if mask is None:
+                        continue
+                    param.data.mul_(mask)
+                    state = optimizer.state.get(param)
+                    if not state:
+                        continue
+                    for value in state.values():
+                        if torch.is_tensor(value) and value.shape == param.data.shape:
+                            value.mul_(mask)
+
             # Update progress bar description every batch for better visibility
             if args.model in ('gpt2', 'nanogpt'):
                 # Calculate actual samples processed (handle variable batch sizes correctly)


### PR DESCRIPTION
## Summary
- reapply weight masks after each optimizer step during masked retraining
- clear optimizer state tensors for masked parameters so they cannot resurrect pruned weights

## Testing
- ❌ `python Deep-CompressionV4/pruning.py --mode prune --model nanogpt --epochs 3 --retrain-epochs 1 --pruning-method neuronrank --target-sparsity 0.9 --seed 42 --skip-model-save --checkpoint Deep-CompressionV4/benchmark_outputs/checkpoints/seed_42/epochs_3.pt --metrics-output /tmp/tmpfaty3pp8.jsonl --gpt2-model-name gpt2 --gpt2-block-size 1024 --nanogpt-n-layer 6 --nanogpt-n-head 6 --nanogpt-n-embd 384 --nanogpt-dropout 0.2 --lr 0.00015 --activation-stats Deep-CompressionV4/benchmark_outputs/activation_stats/seed_42/epochs_3.pt` (fails: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_68d37dfcef8883219241ed6a01ea3831