### PR TITLE
Add NeuronRank ResNet pruning benchmark

### DIFF
--- a/NeuronRank/neronrank/__init__.py
+++ b/NeuronRank/neronrank/__init__.py
@@ -1,0 +1,6 @@
+"""Minimal ResNet pruning benchmarks for NeuronRank."""
+
+__all__ = [
+    "config",
+    "cli",
+]

--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -1,0 +1,263 @@
+"""Command line interface for NeuronRank experiments."""
+from __future__ import annotations
+
+import argparse
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+
+from .config import ExperimentConfig, parse_methods, parse_sparsities
+from .data import DatasetBundle, get_dataset
+from .eval.metrics import evaluate_topk
+from .models import ModelBundle, load_model
+from .pruning import mask, scoring
+from .utils.logging import CSVLogger, MetricRow
+from .utils.seed import resolve_seed, set_seed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="NeuronRank pruning benchmark")
+    parser.add_argument("--hf-model-id", type=str, default=ExperimentConfig.hf_model_id)
+    parser.add_argument("--dataset", type=str, default=ExperimentConfig.dataset)
+    parser.add_argument("--imagenet-val", type=str, default=None)
+    parser.add_argument("--methods", type=parse_methods, default=parse_methods("NR,MB,FO"))
+    parser.add_argument("--statistics", type=str, default="before")
+    parser.add_argument(
+        "--sparsities",
+        type=parse_sparsities,
+        default=parse_sparsities("0.3,0.5,0.7,0.8,0.9,0.95"),
+    )
+    parser.add_argument("--seed", type=int, default=ExperimentConfig.seed)
+    parser.add_argument("--batch-size", type=int, default=ExperimentConfig.batch_size)
+    parser.add_argument("--calib-size", type=int, default=ExperimentConfig.calib_size)
+    parser.add_argument("--num-workers", type=int, default=ExperimentConfig.num_workers)
+    parser.add_argument("--recover-epochs", type=int, default=ExperimentConfig.recover_epochs)
+    parser.add_argument("--lr", type=float, default=ExperimentConfig.lr)
+    parser.add_argument("--weight-decay", type=float, default=ExperimentConfig.weight_decay)
+    parser.add_argument("--momentum", type=float, default=ExperimentConfig.momentum)
+    parser.add_argument("--output-dir", type=Path, default=Path(ExperimentConfig.output_dir))
+    parser.add_argument("--cuda", action="store_true")
+    parser.add_argument("--amp", action="store_true")
+    parser.add_argument("--tfidf-alpha", type=float, default=ExperimentConfig.tfidf_alpha)
+    parser.add_argument("--tfidf-beta", type=float, default=ExperimentConfig.tfidf_beta)
+    parser.add_argument("--tfidf-gamma", type=float, default=ExperimentConfig.tfidf_gamma)
+    parser.add_argument("--log-interval", type=int, default=ExperimentConfig.log_interval)
+    parser.add_argument("--notes", type=str, default="")
+    return parser
+
+
+def determine_device(request_cuda: bool) -> torch.device:
+    if request_cuda and torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cuda" if torch.cuda.is_available() and request_cuda else "cpu")
+
+
+def prepare_output_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def compute_statistics_modes(statistics: str) -> List[str]:
+    statistics = statistics.lower()
+    if statistics == "all":
+        return ["before", "post"]
+    if statistics in ("before", "post"):
+        return [statistics]
+    raise ValueError("--statistics must be one of {before, post, all}")
+
+
+def evaluate_model(bundle: ModelBundle, dataloader, device: torch.device) -> tuple[float, float]:
+    accuracy, elapsed = evaluate_topk(bundle.model, dataloader, device, topk=(1,))
+    return accuracy[1], elapsed
+
+
+def finetune(
+    bundle: ModelBundle,
+    loaders: DatasetBundle,
+    device: torch.device,
+    epochs: int,
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    amp: bool,
+    log_interval: int,
+) -> tuple[float, float, float]:
+    if epochs <= 0:
+        return float("nan"), 0.0, 0.0
+
+    model = bundle.model
+    model.to(device)
+    model.train()
+
+    optimizer = torch.optim.SGD(
+        (p for p in model.parameters() if p.requires_grad),
+        lr=lr,
+        momentum=momentum,
+        weight_decay=weight_decay,
+    )
+    criterion = nn.CrossEntropyLoss()
+    scaler = torch.cuda.amp.GradScaler(enabled=amp and device.type == "cuda")
+
+    epoch_durations: List[float] = []
+
+    for epoch in range(epochs):
+        start = time.time()
+        for step, (inputs, targets) in enumerate(loaders.train):
+            inputs = inputs.to(device)
+            targets = targets.to(device)
+            optimizer.zero_grad(set_to_none=True)
+            with torch.cuda.amp.autocast(enabled=amp and device.type == "cuda"):
+                outputs = model(inputs)
+                if isinstance(outputs, dict):
+                    logits = outputs["logits"]
+                elif hasattr(outputs, "logits"):
+                    logits = outputs.logits
+                else:
+                    logits = outputs
+                loss = criterion(logits, targets)
+            scaler.scale(loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
+            if step % log_interval == 0:
+                pass  # placeholder for future logging
+        epoch_durations.append(time.time() - start)
+
+    ft_accuracy, _ = evaluate_model(bundle, loaders.eval, device)
+    total_time = sum(epoch_durations)
+    avg_time = total_time / len(epoch_durations)
+    return ft_accuracy, total_time, avg_time
+
+
+def compute_scores(
+    method: str,
+    statistics_mode: List[str],
+    base_bundle: ModelBundle,
+    loaders: DatasetBundle,
+    device: torch.device,
+    args: argparse.Namespace,
+) -> Dict[str, torch.Tensor]:
+    method = method.upper()
+    scores: Dict[str, torch.Tensor] = {}
+
+    if method == "MB":
+        base = scoring.magnitude_scores(base_bundle.classifier)
+        for mode in statistics_mode:
+            scores[mode] = base
+    elif method == "NR":
+        stats_mode = "all" if len(statistics_mode) > 1 else statistics_mode[0]
+        scores = scoring.neuronrank_scores(
+            base_bundle.model,
+            base_bundle.classifier,
+            base_bundle.classifier,
+            loaders.calibration,
+            device,
+            stats_mode,  # type: ignore[arg-type]
+            alpha=args.tfidf_alpha,
+            beta=args.tfidf_beta,
+            gamma=args.tfidf_gamma,
+            limit=args.calib_size,
+        )
+    elif method == "FO":
+        base = scoring.first_order_scores(
+            base_bundle.model,
+            base_bundle.classifier,
+            loaders.calibration,
+            device,
+            limit=args.calib_size,
+        )
+        for mode in statistics_mode:
+            scores[mode] = base
+    else:
+        raise ValueError(f"Unknown method: {method}")
+    return scores
+
+
+def run(args: argparse.Namespace) -> None:
+    prepare_output_dir(args.output_dir)
+    device = determine_device(args.cuda)
+    seed = resolve_seed(args.seed)
+    set_seed(seed)
+
+    loaders = get_dataset(
+        args.dataset,
+        args.batch_size,
+        args.calib_size,
+        args.num_workers,
+        seed,
+        imagenet_val=args.imagenet_val,
+    )
+
+    base_bundle = load_model(args.hf_model_id, device, use_cuda=args.cuda, num_classes=loaders.num_classes)
+    base_bundle.model.to(device)
+
+    metrics_path = args.output_dir / "metrics.csv"
+    logger = CSVLogger(str(metrics_path))
+    statistics_modes = compute_statistics_modes(args.statistics)
+
+    for method in args.methods:
+        score_time_start = time.time()
+        if device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(device)
+        score_tensors = compute_scores(method, statistics_modes, base_bundle, loaders, device, args)
+        score_time = time.time() - score_time_start
+        peak_mem = (
+            torch.cuda.max_memory_allocated(device) / 1024**2 if device.type == "cuda" else 0.0
+        )
+
+        for stats_mode, scores in score_tensors.items():
+            for sparsity in args.sparsities:
+                keep_indices = mask.build_keep_indices(scores, sparsity)
+                pruned_bundle = mask.apply_pruning(base_bundle, keep_indices)
+                pruned_bundle.model.to(device)
+
+                kept_params = mask.count_parameters(pruned_bundle.model)
+                zero_acc, eval_time = evaluate_model(pruned_bundle, loaders.eval, device)
+
+                ft_acc, ft_total_time, ft_epoch_avg = finetune(
+                    pruned_bundle,
+                    loaders,
+                    device,
+                    args.recover_epochs,
+                    args.lr,
+                    args.weight_decay,
+                    args.momentum,
+                    args.amp,
+                    args.log_interval,
+                )
+
+                timestamp = datetime.utcnow().isoformat()
+                row = MetricRow(
+                    timestamp=timestamp,
+                    seed=seed,
+                    device=str(device),
+                    dataset=args.dataset,
+                    hf_model_id=args.hf_model_id,
+                    layer=base_bundle.classifier_name,
+                    method=method,
+                    statistics=stats_mode,
+                    sparsity=sparsity,
+                    kept_params=kept_params,
+                    zero_shot_acc_top1=zero_acc,
+                    zero_shot_eval_time_s=eval_time,
+                    score_time_s=score_time,
+                    score_peak_mem_mb=peak_mem,
+                    ft_epochs=args.recover_epochs,
+                    ft_epoch_time_avg_s=ft_epoch_avg,
+                    ft_total_time_s=ft_total_time,
+                    ft_acc_top1=ft_acc,
+                    notes=args.notes,
+                )
+                logger.log(row)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/NeuronRank/neronrank/config.py
+++ b/NeuronRank/neronrank/config.py
@@ -1,0 +1,64 @@
+"""Configuration helpers for NeuronRank."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class ExperimentConfig:
+    """Default hyper-parameters used by the CLI."""
+
+    seed: int = 17
+    batch_size: int = 128
+    calib_size: int = 2048
+    num_workers: int = 4
+    lr: float = 1e-4
+    weight_decay: float = 0.0
+    momentum: float = 0.9
+    recover_epochs: int = 1
+    methods: List[str] = field(default_factory=lambda: ["NR", "MB", "FO"])
+    statistics: str = "before"
+    sparsities: List[float] = field(
+        default_factory=lambda: [0.3, 0.5, 0.7, 0.8, 0.9, 0.95]
+    )
+    hf_model_id: str = "edadaltocg/resnet18_cifar10"
+    dataset: str = "cifar10"
+    imagenet_val: str | None = None
+    output_dir: str = "runs/resnet18-cifar10"
+    cuda: bool = False
+    amp: bool = False
+    tfidf_alpha: float = 1.0
+    tfidf_beta: float = 1.0
+    tfidf_gamma: float = 1.0
+    log_interval: int = 10
+
+
+def parse_sparsities(raw: str) -> List[float]:
+    """Parse a comma separated sparsity list."""
+
+    sparsities: List[float] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        value = float(item)
+        if not 0.0 <= value < 1.0:
+            raise ValueError(f"Invalid sparsity value: {value}")
+        sparsities.append(value)
+    if not sparsities:
+        raise ValueError("At least one sparsity must be provided")
+    return sparsities
+
+
+def parse_methods(raw: str) -> List[str]:
+    """Parse a comma separated method list."""
+
+    methods = [item.strip().upper() for item in raw.split(",") if item.strip()]
+    valid = {"MB", "NR", "FO"}
+    for method in methods:
+        if method not in valid:
+            raise ValueError(f"Unsupported method '{method}'. Supported: {sorted(valid)}")
+    if not methods:
+        raise ValueError("No pruning methods selected")
+    return methods

--- a/NeuronRank/neronrank/data.py
+++ b/NeuronRank/neronrank/data.py
@@ -1,0 +1,161 @@
+"""Dataset loading utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from datasets import load_dataset
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import transforms
+
+from .utils.seed import worker_init_fn
+
+
+@dataclass
+class DatasetBundle:
+    """Container for loaders used in experiments."""
+
+    train: DataLoader
+    calibration: DataLoader
+    eval: DataLoader
+    num_classes: int
+
+
+class HFImageDataset(Dataset):
+    """Wrap a Hugging Face vision dataset in a PyTorch Dataset."""
+
+    def __init__(self, hf_dataset, transform) -> None:
+        self.dataset = hf_dataset
+        self.transform = transform
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.dataset)
+
+    def __getitem__(self, idx: int):  # type: ignore[override]
+        item = self.dataset[idx]
+        image = item["img"] if "img" in item else item["image"]
+        if self.transform is not None:
+            image = self.transform(image)
+        label = item["label"]
+        return image, label
+
+
+def build_cifar10_loaders(
+    batch_size: int,
+    calib_size: int,
+    num_workers: int,
+    seed: int,
+) -> DatasetBundle:
+    """Return loaders for CIFAR-10 using HF datasets."""
+
+    transform_train = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+        ]
+    )
+    transform_test = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+        ]
+    )
+
+    dataset = load_dataset("cifar10")
+    train_dataset = HFImageDataset(dataset["train"], transform_train)
+    test_dataset = HFImageDataset(dataset["test"], transform_test)
+
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    calib_indices = torch.randperm(len(train_dataset), generator=generator)[:calib_size]
+    calib_dataset = Subset(train_dataset, calib_indices.tolist())
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=True,
+        worker_init_fn=worker_init_fn,
+    )
+    calib_loader = DataLoader(
+        calib_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+        worker_init_fn=worker_init_fn,
+    )
+    eval_loader = DataLoader(
+        test_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+        worker_init_fn=worker_init_fn,
+    )
+    return DatasetBundle(train_loader, calib_loader, eval_loader, num_classes=10)
+
+
+def build_imagenet_loaders(
+    val_dir: str,
+    batch_size: int,
+    calib_size: int,
+    num_workers: int,
+    seed: int,
+) -> DatasetBundle:
+    """ImageNet loaders based on torchvision dataset API."""
+
+    from torchvision.datasets import ImageFolder
+
+    normalize = transforms.Normalize(
+        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+    )
+    transform = transforms.Compose(
+        [transforms.Resize(256), transforms.CenterCrop(224), transforms.ToTensor(), normalize]
+    )
+
+    val_dataset = ImageFolder(val_dir, transform=transform)
+
+    if calib_size > len(val_dataset):
+        raise ValueError("Calibration size cannot exceed number of validation examples")
+
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    calib_indices = torch.randperm(len(val_dataset), generator=generator)[:calib_size]
+    calib_dataset = Subset(val_dataset, calib_indices.tolist())
+
+    loader_kwargs = dict(
+        batch_size=batch_size,
+        num_workers=num_workers,
+        pin_memory=True,
+        worker_init_fn=worker_init_fn,
+    )
+
+    calib_loader = DataLoader(calib_dataset, shuffle=False, **loader_kwargs)
+    eval_loader = DataLoader(val_dataset, shuffle=False, **loader_kwargs)
+    # For simplicity we fine-tune on calibration subset when ImageNet val only
+    train_loader = DataLoader(calib_dataset, shuffle=True, **loader_kwargs)
+    return DatasetBundle(train_loader, calib_loader, eval_loader, num_classes=1000)
+
+
+def get_dataset(
+    dataset: str,
+    batch_size: int,
+    calib_size: int,
+    num_workers: int,
+    seed: int,
+    imagenet_val: str | None = None,
+) -> DatasetBundle:
+    """Factory dispatch for dataset loaders."""
+
+    dataset = dataset.lower()
+    if dataset == "cifar10":
+        return build_cifar10_loaders(batch_size, calib_size, num_workers, seed)
+    if dataset == "imagenet":
+        if not imagenet_val:
+            raise ValueError("--imagenet-val must be provided for ImageNet")
+        return build_imagenet_loaders(
+            imagenet_val, batch_size, calib_size, num_workers, seed
+        )
+    raise ValueError(f"Unsupported dataset: {dataset}")

--- a/NeuronRank/neronrank/eval/__init__.py
+++ b/NeuronRank/neronrank/eval/__init__.py
@@ -1,0 +1,6 @@
+"""Evaluation utilities."""
+
+from .metrics import evaluate_topk, spearman_correlation
+from .imagenet_eval import evaluate_imagenet
+
+__all__ = ["evaluate_topk", "spearman_correlation", "evaluate_imagenet"]

--- a/NeuronRank/neronrank/eval/imagenet_eval.py
+++ b/NeuronRank/neronrank/eval/imagenet_eval.py
@@ -1,0 +1,19 @@
+"""ImageNet evaluation helpers."""
+from __future__ import annotations
+
+from typing import Dict, Sequence, Tuple
+
+import torch
+
+from .metrics import evaluate_topk
+
+
+def evaluate_imagenet(
+    model,
+    dataloader,
+    device: torch.device,
+    topk: Sequence[int] = (1, 5),
+) -> Tuple[Dict[int, float], float]:
+    """Evaluate on ImageNet validation set."""
+
+    return evaluate_topk(model, dataloader, device, topk)

--- a/NeuronRank/neronrank/eval/metrics.py
+++ b/NeuronRank/neronrank/eval/metrics.py
@@ -1,0 +1,58 @@
+"""Metric utilities."""
+from __future__ import annotations
+
+import time
+from typing import Dict, Iterable, Sequence, Tuple
+
+import torch
+
+try:  # pragma: no cover - optional dependency
+    from scipy import stats
+except Exception:  # pragma: no cover - optional dependency
+    stats = None  # type: ignore
+
+
+def evaluate_topk(
+    model,
+    dataloader,
+    device: torch.device,
+    topk: Sequence[int] = (1,),
+) -> Tuple[Dict[int, float], float]:
+    """Return top-k accuracy (%) and elapsed seconds."""
+
+    model.eval()
+    total = 0
+    correct = {k: 0 for k in topk}
+    start = time.time()
+    with torch.no_grad():
+        for inputs, targets in dataloader:
+            inputs = inputs.to(device)
+            targets = targets.to(device)
+            outputs = model(inputs)
+            if isinstance(outputs, dict):
+                logits = outputs["logits"]
+            elif hasattr(outputs, "logits"):
+                logits = outputs.logits
+            else:
+                logits = outputs
+            _, pred = logits.topk(max(topk), dim=1, largest=True, sorted=True)
+            total += targets.size(0)
+            for k in topk:
+                correct[k] += pred[:, :k].eq(targets.unsqueeze(1)).any(dim=1).sum().item()
+    elapsed = time.time() - start
+    accuracy = {k: correct[k] * 100.0 / total for k in topk}
+    return accuracy, elapsed
+
+
+def spearman_correlation(x: Iterable[float], y: Iterable[float]) -> float:
+    """Compute Spearman rho between two sequences."""
+
+    x_list = list(x)
+    y_list = list(y)
+    if len(x_list) != len(y_list):
+        raise ValueError("Sequences must have equal length")
+    if len(x_list) < 2:
+        return float("nan")
+    if stats is None:
+        raise RuntimeError("scipy is required for Spearman correlation")
+    return float(stats.spearmanr(x_list, y_list).correlation)

--- a/NeuronRank/neronrank/models/__init__.py
+++ b/NeuronRank/neronrank/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model loading helpers."""
+
+from .resnet_loader import ModelBundle, load_model
+
+__all__ = ["ModelBundle", "load_model"]

--- a/NeuronRank/neronrank/models/resnet_loader.py
+++ b/NeuronRank/neronrank/models/resnet_loader.py
@@ -1,0 +1,70 @@
+"""Utilities to fetch Hugging Face ResNet checkpoints."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from transformers import AutoConfig, AutoModelForImageClassification
+
+
+@dataclass
+class ModelBundle:
+    """Container with model and classifier metadata."""
+
+    model: nn.Module
+    classifier: nn.Linear
+    classifier_name: str
+    feature_dim: int
+
+
+def _find_classifier(model: nn.Module) -> tuple[str, nn.Linear]:
+    """Locate the final linear classifier layer."""
+
+    candidate_names = ["classifier", "fc", "head"]
+    for name in candidate_names:
+        if hasattr(model, name):
+            module = getattr(model, name)
+            if isinstance(module, nn.Linear):
+                return name, module
+            # Some models wrap classifier in Sequential
+            if isinstance(module, nn.Sequential):
+                for idx, submodule in enumerate(module):
+                    if isinstance(submodule, nn.Linear):
+                        return f"{name}.{idx}", submodule
+    # Fallback: search entire module list
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear) and module.out_features >= 10:
+            return name, module
+    raise ValueError("Could not locate a linear classifier in the model")
+
+
+def load_model(
+    hf_model_id: str,
+    device: torch.device,
+    use_cuda: bool,
+    num_classes: Optional[int] = None,
+) -> ModelBundle:
+    """Load a Hugging Face classification model and locate its classifier."""
+
+    config = AutoConfig.from_pretrained(hf_model_id)
+    if num_classes is not None and config.num_labels != num_classes:
+        config.num_labels = num_classes
+    model = AutoModelForImageClassification.from_pretrained(hf_model_id, config=config)
+    model.to(device)
+    model.eval()
+
+    classifier_name, classifier = _find_classifier(model)
+    feature_dim = classifier.in_features
+
+    if classifier.out_features != config.num_labels:
+        raise ValueError(
+            "Classifier output dimension does not match dataset labels: "
+            f"{classifier.out_features} != {config.num_labels}"
+        )
+
+    if use_cuda and torch.cuda.is_available():
+        model = model.cuda()
+
+    return ModelBundle(model=model, classifier=classifier, classifier_name=classifier_name, feature_dim=feature_dim)

--- a/NeuronRank/neronrank/pruning/__init__.py
+++ b/NeuronRank/neronrank/pruning/__init__.py
@@ -1,0 +1,5 @@
+"""Pruning utilities exposed for convenience."""
+
+from . import hooks, mask, scoring, surgery
+
+__all__ = ["hooks", "mask", "scoring", "surgery"]

--- a/NeuronRank/neronrank/pruning/hooks.py
+++ b/NeuronRank/neronrank/pruning/hooks.py
@@ -1,0 +1,62 @@
+"""Forward hook utilities for activation statistics."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Dict, Iterable, List, Literal, Tuple
+
+import torch
+import torch.nn as nn
+
+StatisticsMode = Literal["before", "post", "all"]
+
+
+def _flatten_activation(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dim() == 2:
+        return tensor
+    return tensor.flatten(start_dim=1)
+
+
+def collect_activations(
+    model: nn.Module,
+    module: nn.Module,
+    dataloader,
+    device: torch.device,
+    mode: StatisticsMode,
+    limit: int | None = None,
+) -> Dict[str, torch.Tensor]:
+    """Run the model and collect activations according to the selected mode."""
+
+    storage: Dict[str, List[torch.Tensor]] = {"before": [], "post": []}
+
+    def pre_hook(_module, inputs):
+        storage["before"].append(_flatten_activation(inputs[0].detach().cpu()))
+
+    def post_hook(_module, _inputs, outputs):
+        storage["post"].append(_flatten_activation(outputs.detach().cpu()))
+
+    handles = []
+    if mode in ("before", "all"):
+        handles.append(module.register_forward_pre_hook(pre_hook))
+    if mode in ("post", "all"):
+        handles.append(module.register_forward_hook(post_hook))
+
+    model.eval()
+    processed = 0
+    with torch.no_grad():
+        for batch in dataloader:
+            inputs, _ = batch
+            inputs = inputs.to(device)
+            model(inputs)
+            processed += inputs.size(0)
+            if limit is not None and processed >= limit:
+                break
+
+    for handle in handles:
+        handle.remove()
+
+    results: Dict[str, torch.Tensor] = {}
+    if storage["before"]:
+        results["before"] = torch.cat(storage["before"], dim=0)
+    if storage["post"]:
+        results["post"] = torch.cat(storage["post"], dim=0)
+    return results

--- a/NeuronRank/neronrank/pruning/mask.py
+++ b/NeuronRank/neronrank/pruning/mask.py
@@ -1,0 +1,78 @@
+"""Mask creation and application."""
+from __future__ import annotations
+
+import copy
+from typing import List, Sequence
+
+import torch
+import torch.nn as nn
+
+from ..models.resnet_loader import ModelBundle
+
+
+class PrunedLinear(nn.Module):
+    """Linear layer that selects a subset of input features."""
+
+    def __init__(self, base: nn.Linear, keep_indices: Sequence[int]) -> None:
+        super().__init__()
+        keep = torch.tensor(sorted(keep_indices), dtype=torch.long)
+        self.register_buffer("keep_indices", keep)
+        out_features = base.out_features
+        in_features = len(keep)
+        self.linear = nn.Linear(in_features, out_features, bias=base.bias is not None)
+        with torch.no_grad():
+            self.linear.weight.copy_(base.weight[:, keep])
+            if base.bias is not None and self.linear.bias is not None:
+                self.linear.bias.copy_(base.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        x = x.index_select(-1, self.keep_indices)
+        return self.linear(x)
+
+
+def _set_module_by_name(model: nn.Module, name: str, module: nn.Module) -> None:
+    parts = name.split(".")
+    parent = model
+    for part in parts[:-1]:
+        if part.isdigit():
+            parent = parent[int(part)]
+        else:
+            parent = getattr(parent, part)
+    last = parts[-1]
+    if last.isdigit():
+        parent[int(last)] = module
+    else:
+        setattr(parent, last, module)
+
+
+def build_keep_indices(scores: torch.Tensor, sparsity: float) -> List[int]:
+    """Return indices of neurons to keep given a sparsity."""
+
+    num_features = scores.numel()
+    keep_count = max(1, int(round((1.0 - sparsity) * num_features)))
+    keep_count = min(keep_count, num_features)
+    sorted_indices = torch.argsort(scores, descending=True)
+    keep = sorted_indices[:keep_count].tolist()
+    keep.sort()
+    return keep
+
+
+def apply_pruning(bundle: ModelBundle, keep_indices: Sequence[int]) -> ModelBundle:
+    """Return a new model bundle with classifier columns removed."""
+
+    new_model = copy.deepcopy(bundle.model)
+    base_classifier = copy.deepcopy(bundle.classifier)
+    pruned = PrunedLinear(base_classifier, keep_indices)
+    _set_module_by_name(new_model, bundle.classifier_name, pruned)
+    return ModelBundle(
+        model=new_model,
+        classifier=pruned.linear,
+        classifier_name=bundle.classifier_name,
+        feature_dim=len(keep_indices),
+    )
+
+
+def count_parameters(model: nn.Module) -> int:
+    """Total number of trainable parameters."""
+
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)

--- a/NeuronRank/neronrank/pruning/scoring.py
+++ b/NeuronRank/neronrank/pruning/scoring.py
@@ -1,0 +1,85 @@
+"""Scoring implementations for neuron pruning."""
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+from .hooks import StatisticsMode, collect_activations
+
+
+ScoreDict = Dict[str, torch.Tensor]
+
+
+def magnitude_scores(linear: nn.Linear, p: float = 1.0) -> torch.Tensor:
+    """Compute magnitude-based scores (L1 by default)."""
+
+    weight = linear.weight.detach().abs()
+    if p == 2.0:
+        return torch.sqrt((weight**2).sum(dim=0)).cpu()
+    return weight.sum(dim=0).cpu()
+
+
+def neuronrank_scores(
+    model: nn.Module,
+    linear: nn.Linear,
+    module: nn.Module,
+    dataloader,
+    device: torch.device,
+    mode: StatisticsMode,
+    alpha: float = 1.0,
+    beta: float = 1.0,
+    gamma: float = 1.0,
+    limit: int | None = None,
+) -> ScoreDict:
+    """Compute NeuronRank (TF-IDF × magnitude) scores."""
+
+    activations = collect_activations(model, module, dataloader, device, mode, limit)
+    weight_mag = magnitude_scores(linear).cpu()
+    scores: ScoreDict = {}
+
+    for key, acts in activations.items():
+        total = acts.shape[0]
+        tf = acts.abs().mean(dim=0)
+        df = (acts.abs() > 1e-6).float().sum(dim=0)
+        idf = torch.log((total + 1.0) / (df + 1.0))
+        scores[key] = ((weight_mag**alpha) * (tf**beta) * (idf**gamma)).cpu()
+    return scores
+
+
+def first_order_scores(
+    model: nn.Module,
+    linear: nn.Linear,
+    dataloader,
+    device: torch.device,
+    limit: int | None = None,
+) -> torch.Tensor:
+    """Compute first-order Taylor scores summed per neuron."""
+
+    criterion = nn.CrossEntropyLoss()
+    grads = torch.zeros(linear.in_features, device=device)
+
+    processed = 0
+    was_training = model.training
+    model.train()
+    for inputs, targets in dataloader:
+        inputs = inputs.to(device)
+        targets = targets.to(device)
+        model.zero_grad(set_to_none=True)
+        outputs = model(inputs)
+        if isinstance(outputs, dict):
+            logits = outputs["logits"]
+        elif hasattr(outputs, "logits"):
+            logits = outputs.logits
+        else:
+            logits = outputs
+        loss = criterion(logits, targets)
+        loss.backward()
+        grads = grads + (linear.weight.grad * linear.weight).abs().sum(dim=0)
+        processed += inputs.size(0)
+        if limit is not None and processed >= limit:
+            break
+    if was_training is False:
+        model.eval()
+    return grads.detach().cpu()

--- a/NeuronRank/neronrank/pruning/surgery.py
+++ b/NeuronRank/neronrank/pruning/surgery.py
@@ -1,0 +1,27 @@
+"""Optional least-squares recovery utilities."""
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+try:
+    import scipy.linalg  # type: ignore
+except Exception:  # pragma: no cover - scipy optional
+    scipy = None  # type: ignore
+
+
+def lsq_recover(
+    features: torch.Tensor,
+    targets: torch.Tensor,
+    damping: float = 1e-4,
+) -> torch.Tensor:
+    """Solve a damped least squares problem for weight recovery."""
+
+    if scipy is None:
+        raise RuntimeError("scipy is required for least-squares recovery")
+
+    x = features.detach().cpu().numpy()
+    y = targets.detach().cpu().numpy()
+    gram = x.T @ x + damping * np.eye(x.shape[1])
+    sol = scipy.linalg.solve(gram, x.T @ y, assume_a="pos")
+    return torch.from_numpy(sol)

--- a/NeuronRank/neronrank/utils/__init__.py
+++ b/NeuronRank/neronrank/utils/__init__.py
@@ -1,0 +1,12 @@
+"""Utility helpers for NeuronRank."""
+
+from .logging import CSVLogger, MetricRow
+from .seed import resolve_seed, set_seed, worker_init_fn
+
+__all__ = [
+    "CSVLogger",
+    "MetricRow",
+    "resolve_seed",
+    "set_seed",
+    "worker_init_fn",
+]

--- a/NeuronRank/neronrank/utils/logging.py
+++ b/NeuronRank/neronrank/utils/logging.py
@@ -1,0 +1,66 @@
+"""Logging helpers."""
+from __future__ import annotations
+
+import csv
+import os
+from dataclasses import asdict, dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class MetricRow:
+    timestamp: str
+    seed: int
+    device: str
+    dataset: str
+    hf_model_id: str
+    layer: str
+    method: str
+    statistics: str
+    sparsity: float
+    kept_params: int
+    zero_shot_acc_top1: float
+    zero_shot_eval_time_s: float
+    score_time_s: float
+    score_peak_mem_mb: float
+    ft_epochs: int
+    ft_epoch_time_avg_s: float
+    ft_total_time_s: float
+    ft_acc_top1: float
+    notes: str = ""
+
+
+class CSVLogger:
+    """Append-only CSV writer with header management."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._header_written = False
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    def log(self, row: MetricRow) -> None:
+        data = asdict(row)
+        write_header = not os.path.exists(self.path) or not self._header_written
+        with open(self.path, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=list(data.keys()))
+            if write_header:
+                writer.writeheader()
+                self._header_written = True
+            writer.writerow(data)
+
+    def log_many(self, rows: Iterable[MetricRow]) -> None:
+        for row in rows:
+            self.log(row)
+
+
+def format_metrics_table(rows: List[MetricRow]) -> str:
+    """Create a Markdown table for quick inspection."""
+
+    if not rows:
+        return ""
+    headers = list(asdict(rows[0]).keys())
+    lines = ["| " + " | ".join(headers) + " |", "|" + "---|" * len(headers)]
+    for row in rows:
+        values = [str(asdict(row)[key]) for key in headers]
+        lines.append("| " + " | ".join(values) + " |")
+    return "\n".join(lines)

--- a/NeuronRank/neronrank/utils/seed.py
+++ b/NeuronRank/neronrank/utils/seed.py
@@ -1,0 +1,39 @@
+"""Utilities for deterministic execution."""
+from __future__ import annotations
+
+import os
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+def set_seed(seed: int, deterministic: bool = True) -> None:
+    """Seed Python, NumPy and PyTorch RNGs."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    if deterministic:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+def worker_init_fn(worker_id: int) -> None:
+    """Seed worker processes in data loaders."""
+
+    base_seed = torch.initial_seed() % 2**32
+    np.random.seed(base_seed + worker_id)
+    random.seed(base_seed + worker_id)
+
+
+def resolve_seed(seed: Optional[int]) -> int:
+    """Resolve the experiment seed from the environment if necessary."""
+
+    if seed is not None:
+        return seed
+    env_seed = os.getenv("NEURONRANK_SEED")
+    return int(env_seed) if env_seed is not None else 0

--- a/NeuronRank/neronrank/viz/__init__.py
+++ b/NeuronRank/neronrank/viz/__init__.py
@@ -1,0 +1,5 @@
+"""Visualization helpers."""
+
+from .plots import main as plot_main
+
+__all__ = ["plot_main"]

--- a/NeuronRank/neronrank/viz/plots.py
+++ b/NeuronRank/neronrank/viz/plots.py
@@ -1,0 +1,80 @@
+"""Plotting utilities for NeuronRank experiments."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+COLORS = {
+    "MB": "#1f77b4",
+    "NR": "#2ca02c",
+    "FO": "#d62728",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plot accuracy vs parameter count")
+    parser.add_argument("--csv", type=Path, required=True, help="Path to metrics.csv")
+    parser.add_argument("--out", type=Path, required=True, help="Output image path")
+    parser.add_argument(
+        "--statistics",
+        type=str,
+        default=None,
+        help="Filter to a specific statistics mode (before/post)",
+    )
+    parser.add_argument(
+        "--with-ft",
+        action="store_true",
+        help="Include fine-tuned accuracy markers",
+    )
+    return parser
+
+
+def main(args: argparse.Namespace) -> None:
+    df = pd.read_csv(args.csv)
+    if args.statistics is not None:
+        df = df[df["statistics"] == args.statistics]
+    if df.empty:
+        raise SystemExit("No rows to plot after filtering")
+
+    methods = sorted(df["method"].unique())
+    plt.figure(figsize=(8, 5))
+
+    for method in methods:
+        subset = df[df["method"] == method].sort_values("kept_params")
+        color = COLORS.get(method, None)
+        plt.plot(
+            subset["kept_params"],
+            subset["zero_shot_acc_top1"],
+            label=f"{method} (zero-shot)",
+            marker="o",
+            color=color,
+        )
+        if args.with_ft:
+            plt.plot(
+                subset["kept_params"],
+                subset["ft_acc_top1"],
+                label=f"{method} (+FT)",
+                marker="x",
+                linestyle="--",
+                color=color,
+            )
+
+    plt.xlabel("Parameters kept")
+    plt.ylabel("Top-1 Accuracy (%)")
+    plt.title("Accuracy vs Parameter Count")
+    plt.legend()
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(args.out)
+    plt.close()
+
+
+if __name__ == "__main__":
+    parser = build_parser()
+    main(parser.parse_args())

--- a/NeuronRank/requirements.txt
+++ b/NeuronRank/requirements.txt
@@ -1,0 +1,9 @@
+torch
+torchvision
+transformers
+datasets
+timm
+pandas
+matplotlib
+scipy
+tqdm

--- a/NeuronRank/scripts/plot_results.sh
+++ b/NeuronRank/scripts/plot_results.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CSV_PATH="${1:-runs/resnet18-cifar10/metrics.csv}"
+OUT_PATH="${2:-runs/resnet18-cifar10/acc_vs_params.png}"
+
+python -m neronrank.viz.plots --csv "${CSV_PATH}" --out "${OUT_PATH}" --with-ft

--- a/NeuronRank/scripts/run_resnet_cifar10.sh
+++ b/NeuronRank/scripts/run_resnet_cifar10.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="runs/resnet18-cifar10"
+python -m neronrank.cli \
+  --hf-model-id edadaltocg/resnet18_cifar10 \
+  --dataset cifar10 \
+  --methods NR,MB,FO \
+  --statistics before \
+  --sparsities 0.3,0.5,0.7,0.8,0.9,0.95 \
+  --calib-size 4096 \
+  --batch-size 128 \
+  --recover-epochs 1 \
+  --lr 1e-4 \
+  --output-dir "${OUT}" \
+  --cuda
+
+python -m neronrank.viz.plots --csv "${OUT}/metrics.csv" --out "${OUT}/acc_vs_params.png"

--- a/NeuronRank/scripts/run_resnet_imagenet.sh
+++ b/NeuronRank/scripts/run_resnet_imagenet.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMNET_VAL="/path/to/imagenet/val"
+OUT="runs/resnet50-imagenet"
+
+python -m neronrank.cli \
+  --hf-model-id timm/resnet50.a1_in1k \
+  --dataset imagenet \
+  --imagenet-val "${IMNET_VAL}" \
+  --methods NR,MB,FO \
+  --statistics before \
+  --sparsities 0.3,0.5,0.7,0.8,0.9,0.95 \
+  --calib-size 4096 \
+  --batch-size 256 \
+  --recover-epochs 1 \
+  --lr 1e-4 \
+  --output-dir "${OUT}" \
+  --cuda
+
+python -m neronrank.viz.plots --csv "${OUT}/metrics.csv" --out "${OUT}/acc_vs_params.png"


### PR DESCRIPTION
## Summary
- add a dedicated `neronrank` package with a CLI that loads Hugging Face ResNet checkpoints, applies MB/NR/FO scoring, and logs pruning sweeps
- implement dataset loaders, scoring hooks/masks, and utilities for pruning, fine-tuning, and metric logging
- ship plotting helpers and runnable scripts for CIFAR-10 and ImageNet experiments

## Testing
- python -m compileall NeuronRank/neronrank

------
https://chatgpt.com/codex/tasks/task_e_68d4f81c25b883219016eced86667e16