### PR TITLE
Improve dataset handling and logging for NeuronRank

### DIFF
--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
@@ -181,13 +182,37 @@ def run(args: argparse.Namespace) -> None:
     seed = resolve_seed(args.seed)
     set_seed(seed)
 
-    loaders = get_dataset(
-        args.dataset,
-        args.batch_size,
-        args.calib_size,
-        args.num_workers,
-        seed,
-        imagenet_val=args.imagenet_val,
+    print(
+        f"[NeuronRank] Using device: {device} | seed={seed} | dataset={args.dataset}",
+        flush=True,
+    )
+    print("[NeuronRank] Preparing data loaders…", flush=True)
+    try:
+        loaders = get_dataset(
+            args.dataset,
+            args.batch_size,
+            args.calib_size,
+            args.num_workers,
+            seed,
+            imagenet_val=args.imagenet_val,
+        )
+    except FileNotFoundError as exc:
+        print(f"[NeuronRank] Dataset error: {exc}", file=sys.stderr, flush=True)
+        raise
+
+    def _safe_len(loader):
+        try:
+            return len(loader.dataset)
+        except Exception:  # pragma: no cover - defensive
+            return "?"
+
+    print(
+        "[NeuronRank] Data ready | train={} | calib={} | eval={}".format(
+            _safe_len(loaders.train),
+            _safe_len(loaders.calibration),
+            _safe_len(loaders.eval),
+        ),
+        flush=True,
     )
 
     base_bundle = load_model(
@@ -204,6 +229,7 @@ def run(args: argparse.Namespace) -> None:
     statistics_modes = compute_statistics_modes(args.statistics)
 
     for method in args.methods:
+        print(f"[NeuronRank] Computing scores with method={method}…", flush=True)
         score_time_start = time.time()
         if device.type == "cuda":
             torch.cuda.reset_peak_memory_stats(device)
@@ -215,6 +241,10 @@ def run(args: argparse.Namespace) -> None:
 
         for stats_mode, scores in score_tensors.items():
             for sparsity in args.sparsities:
+                print(
+                    f"[NeuronRank] Evaluating sparsity={sparsity:.2f} ({stats_mode})",
+                    flush=True,
+                )
                 keep_indices = mask.build_keep_indices(scores, sparsity)
                 pruned_bundle = mask.apply_pruning(base_bundle, keep_indices)
                 pruned_bundle.model.to(device)
@@ -257,6 +287,10 @@ def run(args: argparse.Namespace) -> None:
                     notes=args.notes,
                 )
                 logger.log(row)
+                print(
+                    f"[NeuronRank] Logged results | method={method} | stats={stats_mode} | sparsity={sparsity:.2f}",
+                    flush=True,
+                )
 
 
 def main() -> None:

--- a/NeuronRank/neronrank/data.py
+++ b/NeuronRank/neronrank/data.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import torch
 from datasets import load_dataset
@@ -155,7 +156,18 @@ def get_dataset(
     if dataset == "imagenet":
         if not imagenet_val:
             raise ValueError("--imagenet-val must be provided for ImageNet")
+
+        val_path = Path(imagenet_val).expanduser()
+        if not val_path.exists():
+            raise FileNotFoundError(
+                f"ImageNet validation directory not found: {val_path}"
+            )
+        if not any(val_path.iterdir()):
+            raise FileNotFoundError(
+                f"ImageNet validation directory is empty: {val_path}"
+            )
+
         return build_imagenet_loaders(
-            imagenet_val, batch_size, calib_size, num_workers, seed
+            str(val_path), batch_size, calib_size, num_workers, seed
         )
     raise ValueError(f"Unsupported dataset: {dataset}")

--- a/NeuronRank/scripts/run_resnet_imagenet.sh
+++ b/NeuronRank/scripts/run_resnet_imagenet.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMNET_VAL="/path/to/imagenet/val"
+IMNET_VAL="${1:-${IMAGENET_VAL_DIR:-}}"
 OUT="runs/resnet50-imagenet"
+
+if [[ -z "${IMNET_VAL}" ]]; then
+  echo "[NeuronRank] Please provide the ImageNet validation directory as the first" \
+       "argument or set IMAGENET_VAL_DIR."
+  exit 1
+fi
+
+if [[ ! -d "${IMNET_VAL}" ]]; then
+  echo "[NeuronRank] ImageNet validation directory not found: ${IMNET_VAL}" >&2
+  exit 1
+fi
 
 python -m neronrank.cli \
   --hf-model-id timm/resnet50.a1_in1k \


### PR DESCRIPTION
## Summary
- add informative progress logging and dataset error handling to the CLI
- validate ImageNet validation directory existence before building loaders
- update ImageNet script to require a real validation path via argument or environment variable

## Testing
- ⚠️ `python -m neronrank.cli --help` *(cancelled because torchvision imports block on Triton backend discovery in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d50a4c0f988321be1ddec1bf1857d4