### PR TITLE
Align post statistics with classifier feature space

### DIFF
--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -2,21 +2,39 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, cast
 
 import torch
 import torch.nn as nn
 
-from .config import ExperimentConfig, parse_methods, parse_sparsities
-from .data import DatasetBundle, get_dataset
-from .eval.metrics import evaluate_topk
-from .models import ModelBundle, load_model
-from .pruning import mask, scoring
-from .utils.logging import CSVLogger, MetricRow
-from .utils.seed import resolve_seed, set_seed
+try:  # pragma: no cover - import shim for direct script execution
+    from .config import ExperimentConfig, parse_methods, parse_sparsities
+    from .data import DatasetBundle, get_dataset
+    from .eval.metrics import evaluate_topk
+    from .models import ModelBundle, load_model
+    from .pruning import mask, scoring
+    from .pruning.hooks import StatisticsMode
+    from .utils.logging import CSVLogger, MetricRow
+    from .utils.seed import resolve_seed, set_seed
+except ImportError:  # pragma: no cover - fallback when run as `python cli.py`
+    if __package__ in (None, ""):
+        package_root = Path(__file__).resolve().parent.parent
+        if str(package_root) not in sys.path:
+            sys.path.insert(0, str(package_root))
+        from neronrank.config import ExperimentConfig, parse_methods, parse_sparsities
+        from neronrank.data import DatasetBundle, get_dataset
+        from neronrank.eval.metrics import evaluate_topk
+        from neronrank.models import ModelBundle, load_model
+        from neronrank.pruning import mask, scoring
+        from neronrank.pruning.hooks import StatisticsMode
+        from neronrank.utils.logging import CSVLogger, MetricRow
+        from neronrank.utils.seed import resolve_seed, set_seed
+    else:  # re-raise unexpected import errors inside the package
+        raise
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -51,9 +69,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def determine_device(request_cuda: bool) -> torch.device:
-    if request_cuda and torch.cuda.is_available():
+    if request_cuda:
+        if not torch.cuda.is_available():
+            raise RuntimeError("--cuda requested but no CUDA devices are available")
         return torch.device("cuda")
-    return torch.device("cuda" if torch.cuda.is_available() and request_cuda else "cpu")
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 def prepare_output_dir(path: Path) -> None:
@@ -143,18 +163,22 @@ def compute_scores(
     scores: Dict[str, torch.Tensor] = {}
 
     if method == "MB":
-        base = scoring.magnitude_scores(base_bundle.classifier)
         for mode in statistics_mode:
-            scores[mode] = base
+            stats_mode = cast(StatisticsMode, mode)
+            scores[mode] = scoring.magnitude_scores(
+                base_bundle.classifier,
+                mode=stats_mode,
+            )
     elif method == "NR":
-        stats_mode = "all" if len(statistics_mode) > 1 else statistics_mode[0]
+        raw_mode = "all" if len(statistics_mode) > 1 else statistics_mode[0]
+        stats_mode = cast(StatisticsMode, raw_mode)
         scores = scoring.neuronrank_scores(
             base_bundle.model,
             base_bundle.classifier,
             base_bundle.classifier,
             loaders.calibration,
             device,
-            stats_mode,  # type: ignore[arg-type]
+            stats_mode,
             alpha=args.tfidf_alpha,
             beta=args.tfidf_beta,
             gamma=args.tfidf_gamma,
@@ -181,13 +205,37 @@ def run(args: argparse.Namespace) -> None:
     seed = resolve_seed(args.seed)
     set_seed(seed)
 
-    loaders = get_dataset(
-        args.dataset,
-        args.batch_size,
-        args.calib_size,
-        args.num_workers,
-        seed,
-        imagenet_val=args.imagenet_val,
+    print(
+        f"[NeuronRank] Using device: {device} | seed={seed} | dataset={args.dataset}",
+        flush=True,
+    )
+    print("[NeuronRank] Preparing data loaders…", flush=True)
+    try:
+        loaders = get_dataset(
+            args.dataset,
+            args.batch_size,
+            args.calib_size,
+            args.num_workers,
+            seed,
+            imagenet_val=args.imagenet_val,
+        )
+    except FileNotFoundError as exc:
+        print(f"[NeuronRank] Dataset error: {exc}", file=sys.stderr, flush=True)
+        raise
+
+    def _safe_len(loader):
+        try:
+            return len(loader.dataset)
+        except Exception:  # pragma: no cover - defensive
+            return "?"
+
+    print(
+        "[NeuronRank] Data ready | train={} | calib={} | eval={}".format(
+            _safe_len(loaders.train),
+            _safe_len(loaders.calibration),
+            _safe_len(loaders.eval),
+        ),
+        flush=True,
     )
 
     base_bundle = load_model(
@@ -204,6 +252,7 @@ def run(args: argparse.Namespace) -> None:
     statistics_modes = compute_statistics_modes(args.statistics)
 
     for method in args.methods:
+        print(f"[NeuronRank] Computing scores with method={method}…", flush=True)
         score_time_start = time.time()
         if device.type == "cuda":
             torch.cuda.reset_peak_memory_stats(device)
@@ -215,6 +264,10 @@ def run(args: argparse.Namespace) -> None:
 
         for stats_mode, scores in score_tensors.items():
             for sparsity in args.sparsities:
+                print(
+                    f"[NeuronRank] Evaluating sparsity={sparsity:.2f} ({stats_mode})",
+                    flush=True,
+                )
                 keep_indices = mask.build_keep_indices(scores, sparsity)
                 pruned_bundle = mask.apply_pruning(base_bundle, keep_indices)
                 pruned_bundle.model.to(device)
@@ -257,6 +310,10 @@ def run(args: argparse.Namespace) -> None:
                     notes=args.notes,
                 )
                 logger.log(row)
+                print(
+                    f"[NeuronRank] Logged results | method={method} | stats={stats_mode} | sparsity={sparsity:.2f}",
+                    flush=True,
+                )
 
 
 def main() -> None:

--- a/NeuronRank/neronrank/data.py
+++ b/NeuronRank/neronrank/data.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import torch
 from datasets import load_dataset
@@ -155,7 +156,18 @@ def get_dataset(
     if dataset == "imagenet":
         if not imagenet_val:
             raise ValueError("--imagenet-val must be provided for ImageNet")
+
+        val_path = Path(imagenet_val).expanduser()
+        if not val_path.exists():
+            raise FileNotFoundError(
+                f"ImageNet validation directory not found: {val_path}"
+            )
+        if not any(val_path.iterdir()):
+            raise FileNotFoundError(
+                f"ImageNet validation directory is empty: {val_path}"
+            )
+
         return build_imagenet_loaders(
-            imagenet_val, batch_size, calib_size, num_workers, seed
+            str(val_path), batch_size, calib_size, num_workers, seed
         )
     raise ValueError(f"Unsupported dataset: {dataset}")

--- a/NeuronRank/neronrank/pruning/scoring.py
+++ b/NeuronRank/neronrank/pruning/scoring.py
@@ -12,13 +12,54 @@ from .hooks import StatisticsMode, collect_activations
 ScoreDict = Dict[str, torch.Tensor]
 
 
-def magnitude_scores(linear: nn.Linear, p: float = 1.0) -> torch.Tensor:
-    """Compute magnitude-based scores (L1 by default)."""
+def magnitude_scores(
+    linear: nn.Linear,
+    p: float = 1.0,
+    mode: StatisticsMode | None = None,
+) -> torch.Tensor:
+    """Compute magnitude-based scores (L1 by default).
+
+    The optional ``mode`` argument is accepted for backward compatibility with callers
+    that differentiate between activation orientations, but the returned scores always
+    correspond to the neuron's input features so they can be combined with pruning
+    masks regardless of the chosen statistics mode.
+    """
 
     weight = linear.weight.detach().abs()
     if p == 2.0:
-        return torch.sqrt((weight**2).sum(dim=0)).cpu()
-    return weight.sum(dim=0).cpu()
+        scores = torch.sqrt((weight**2).sum(dim=0))
+    else:
+        scores = weight.sum(dim=0)
+    return scores.cpu()
+
+
+def _project_post_activations(
+    acts: torch.Tensor, weight_abs: torch.Tensor, eps: float = 1e-12
+) -> torch.Tensor:
+    """Project module outputs onto the classifier input space.
+
+    When collecting ``post`` statistics from the linear classifier we only observe the
+    logits produced by the layer. To reuse those statistics for input-neuron pruning we
+    distribute each output activation back to the inputs proportional to the absolute
+    connection strength. The result is a non-negative matrix with the same second
+    dimension as ``weight_abs.shape[1]`` (i.e. the classifier's input width).
+    """
+
+    if acts.dim() != 2:
+        acts = acts.flatten(start_dim=1)
+
+    out_features, in_features = weight_abs.shape
+    if acts.shape[1] != out_features:
+        raise RuntimeError(
+            "Post-activation statistics produced {act_dim} features but the classifier "
+            "exposes {out_dim} outputs; post statistics currently support linear "
+            "classifiers only.".format(act_dim=acts.shape[1], out_dim=out_features)
+        )
+
+    column_sums = weight_abs.sum(dim=0, keepdim=True).clamp_min(eps)
+    mixing = weight_abs / column_sums
+    projected = acts.abs().to(weight_abs.dtype) @ mixing
+    return projected
 
 
 def neuronrank_scores(
@@ -36,15 +77,21 @@ def neuronrank_scores(
     """Compute NeuronRank (TF-IDF × magnitude) scores."""
 
     activations = collect_activations(model, module, dataloader, device, mode, limit)
-    weight_mag = magnitude_scores(linear).cpu()
+    weight_abs = linear.weight.detach().abs().cpu()
+    base_magnitude = magnitude_scores(linear, mode="before")
     scores: ScoreDict = {}
 
     for key, acts in activations.items():
+        if key == "post":
+            acts = _project_post_activations(acts, weight_abs)
+        else:
+            acts = acts.abs()
+
         total = acts.shape[0]
-        tf = acts.abs().mean(dim=0)
-        df = (acts.abs() > 1e-6).float().sum(dim=0)
+        tf = acts.mean(dim=0)
+        df = (acts > 1e-6).float().sum(dim=0)
         idf = torch.log((total + 1.0) / (df + 1.0))
-        scores[key] = ((weight_mag**alpha) * (tf**beta) * (idf**gamma)).cpu()
+        scores[key] = ((base_magnitude**alpha) * (tf**beta) * (idf**gamma)).cpu()
     return scores
 
 

--- a/NeuronRank/scripts/run_resnet_imagenet.sh
+++ b/NeuronRank/scripts/run_resnet_imagenet.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IMNET_VAL="/path/to/imagenet/val"
+IMNET_VAL="${1:-${IMAGENET_VAL_DIR:-}}"
 OUT="runs/resnet50-imagenet"
+
+if [[ -z "${IMNET_VAL}" ]]; then
+  echo "[NeuronRank] Please provide the ImageNet validation directory as the first" \
+       "argument or set IMAGENET_VAL_DIR."
+  exit 1
+fi
+
+if [[ ! -d "${IMNET_VAL}" ]]; then
+  echo "[NeuronRank] ImageNet validation directory not found: ${IMNET_VAL}" >&2
+  exit 1
+fi
 
 python -m neronrank.cli \
   --hf-model-id timm/resnet50.a1_in1k \


### PR DESCRIPTION
## Summary
- default to CUDA automatically when available and raise a clear error if --cuda is requested without a GPU
- project post-activation statistics through the classifier weights so TF-IDF scores always align with input features
- keep magnitude scoring compatible with both statistics modes while reusing a single feature-oriented vector

## Testing
- `python -m compileall neronrank`


------
https://chatgpt.com/codex/tasks/task_e_68d50a4c0f988321be1ddec1bf1857d4