### PR TITLE
Fix post activation projection in neuronrank scoring

### DIFF
--- a/NeuronRank/neronrank/pruning/scoring.py
+++ b/NeuronRank/neronrank/pruning/scoring.py
@@ -92,6 +92,9 @@ def neuronrank_scores(
 
     scores: ScoreDict = {}
 
+    if "post" in activations:
+        weight_abs = linear.weight.detach().abs()
+
     for key, acts in activations.items():
         if key == "post":
             acts = _project_post_activations(acts, weight_abs)


### PR DESCRIPTION
## Summary
- define the absolute weight tensor before projecting post activations in neuronrank scoring
- ensure post-activation projections use the correct classifier weights

## Testing
- `python neronrank/cli.py --statistics post --calib-size 16 --batch-size 16 --dataset cifar10` *(fails: dataset download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d517f03e3c8321a65cb0aefb14611e