### PR TITLE
Fix post activation projection in neuronrank scoring

### DIFF
--- a/NeuronRank/neronrank/pruning/scoring.py
+++ b/NeuronRank/neronrank/pruning/scoring.py
@@ -53,6 +53,9 @@ def _project_post_activations(
     if acts.dim() != 2:
         acts = acts.flatten(start_dim=1)
 
+    if weight_abs.device != acts.device:
+        weight_abs = weight_abs.to(acts.device)
+
     out_features, in_features = weight_abs.shape
     if acts.shape[1] != out_features:
         raise RuntimeError(
@@ -91,6 +94,9 @@ def neuronrank_scores(
         weight_mag["post"] = magnitude_scores(linear, mode="post")
 
     scores: ScoreDict = {}
+
+    if "post" in activations:
+        weight_abs = linear.weight.detach().abs()
 
     for key, acts in activations.items():
         if key == "post":


### PR DESCRIPTION
## Summary
- define the absolute weight tensor before projecting post activations in neuronrank scoring
- ensure post-activation projections use the correct classifier weights
- move classifier weights onto the activation device before computing the post-activation projection to avoid CPU/GPU mismatches

## Testing
- `python -m compileall NeuronRank/neronrank/pruning/scoring.py`


------
https://chatgpt.com/codex/tasks/task_e_68d517f03e3c8321a65cb0aefb14611e