### PR TITLE
Respect recover-epochs flag when logging fine-tuning metrics

### DIFF
--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -284,20 +284,8 @@ def run(args: argparse.Namespace) -> None:
                 kept_params = mask.count_parameters(pruned_bundle.model)
                 zero_acc, eval_time = evaluate_model(pruned_bundle, loaders.eval, device)
 
-                ft_acc, ft_total_time, ft_epoch_avg = finetune(
-                    pruned_bundle,
-                    loaders,
-                    device,
-                    args.recover_epochs,
-                    args.lr,
-                    args.weight_decay,
-                    args.momentum,
-                    args.amp,
-                    args.log_interval,
-                )
-
                 timestamp = datetime.utcnow().isoformat()
-                row = MetricRow(
+                row_data = dict(
                     timestamp=timestamp,
                     seed=seed,
                     device=str(device),
@@ -312,13 +300,33 @@ def run(args: argparse.Namespace) -> None:
                     zero_shot_eval_time_s=eval_time,
                     score_time_s=score_time,
                     score_peak_mem_mb=peak_mem,
-                    ft_epochs=args.recover_epochs,
-                    ft_epoch_time_avg_s=ft_epoch_avg,
-                    ft_total_time_s=ft_total_time,
-                    ft_acc_top1=ft_acc,
+                    ft_epochs=0,
+                    ft_epoch_time_avg_s=0.0,
+                    ft_total_time_s=0.0,
+                    ft_acc_top1=float("nan"),
                     notes=args.notes,
                 )
-                logger.log(row)
+                logger.log(MetricRow(**row_data))
+
+                if args.recover_epochs > 0:
+                    ft_acc, ft_total_time, ft_epoch_avg = finetune(
+                        pruned_bundle,
+                        loaders,
+                        device,
+                        args.recover_epochs,
+                        args.lr,
+                        args.weight_decay,
+                        args.momentum,
+                        args.amp,
+                        args.log_interval,
+                    )
+                    row_data.update(
+                        ft_epochs=args.recover_epochs,
+                        ft_acc_top1=ft_acc,
+                        ft_total_time_s=ft_total_time,
+                        ft_epoch_time_avg_s=ft_epoch_avg,
+                    )
+                    logger.log(MetricRow(**row_data))
                 print(
                     f"[NeuronRank] Logged results | method={method} | stats={stats_mode} | sparsity={sparsity:.2f}",
                     flush=True,

--- a/NeuronRank/neronrank/pruning/scoring.py
+++ b/NeuronRank/neronrank/pruning/scoring.py
@@ -53,6 +53,9 @@ def _project_post_activations(
     if acts.dim() != 2:
         acts = acts.flatten(start_dim=1)
 
+    if weight_abs.device != acts.device:
+        weight_abs = weight_abs.to(acts.device)
+
     out_features, in_features = weight_abs.shape
     if acts.shape[1] != out_features:
         raise RuntimeError(
@@ -91,6 +94,9 @@ def neuronrank_scores(
         weight_mag["post"] = magnitude_scores(linear, mode="post")
 
     scores: ScoreDict = {}
+
+    if "post" in activations:
+        weight_abs = linear.weight.detach().abs()
 
     for key, acts in activations.items():
         if key == "post":


### PR DESCRIPTION
## Summary
- log zero-shot evaluation metrics immediately after pruning for each sparsity level
- skip fine-tuning entirely when --recover-epochs is 0 and only append fine-tuning metrics when epochs are requested

## Testing
- `python -m compileall NeuronRank/neronrank/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68d517f03e3c8321a65cb0aefb14611e