### PR TITLE
Add channel pruning scope with per-layer scoring

### DIFF
--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -6,7 +6,7 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, cast
+from typing import Dict, List, Sequence, cast
 
 import torch
 import torch.nn as nn
@@ -16,7 +16,7 @@ try:  # pragma: no cover - import shim for direct script execution
     from .data import DatasetBundle, get_dataset
     from .eval.metrics import evaluate_topk
     from .models import ModelBundle, load_model
-    from .pruning import mask, scoring
+    from .pruning import channel, mask, scoring
 
 
     from .pruning.hooks import StatisticsMode
@@ -33,7 +33,7 @@ except ImportError:  # pragma: no cover - fallback when run as `python cli.py`
         from neronrank.data import DatasetBundle, get_dataset
         from neronrank.eval.metrics import evaluate_topk
         from neronrank.models import ModelBundle, load_model
-        from neronrank.pruning import mask, scoring
+        from neronrank.pruning import channel, mask, scoring
 
 
         from neronrank.pruning.hooks import StatisticsMode
@@ -53,6 +53,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--imagenet-val", type=str, default=None)
     parser.add_argument("--methods", type=parse_methods, default=parse_methods("NR,MB,FO"))
     parser.add_argument("--statistics", type=str, default="before")
+    parser.add_argument("--scope", type=str, choices=("fc", "all"), default="fc")
     parser.add_argument(
         "--sparsities",
         type=parse_sparsities,
@@ -160,7 +161,7 @@ def finetune(
     return ft_accuracy, total_time, avg_time
 
 
-def compute_scores(
+def compute_classifier_scores(
     method: str,
     statistics_mode: List[str],
     base_bundle: ModelBundle,
@@ -206,6 +207,39 @@ def compute_scores(
     else:
         raise ValueError(f"Unknown method: {method}")
     return scores
+
+
+def compute_channel_scores(
+    method: str,
+    base_bundle: ModelBundle,
+    targets: Sequence[channel.ChannelTarget],
+    loaders: DatasetBundle,
+    device: torch.device,
+    args: argparse.Namespace,
+) -> Dict[str, torch.Tensor]:
+    method = method.upper()
+    if method == "MB":
+        return channel.compute_magnitude_scores(base_bundle.model, targets)
+    if method == "NR":
+        return channel.compute_neuronrank_scores(
+            base_bundle.model,
+            targets,
+            loaders.calibration,
+            device,
+            alpha=args.tfidf_alpha,
+            beta=args.tfidf_beta,
+            gamma=args.tfidf_gamma,
+            limit=args.calib_size,
+        )
+    if method == "FO":
+        return channel.compute_first_order_scores(
+            base_bundle.model,
+            targets,
+            loaders.calibration,
+            device,
+            limit=args.calib_size,
+        )
+    raise ValueError(f"Unknown method: {method}")
 
 
 def run(args: argparse.Namespace) -> None:
@@ -259,70 +293,165 @@ def run(args: argparse.Namespace) -> None:
     metrics_path = args.output_dir / "metrics.csv"
     logger = CSVLogger(str(metrics_path))
     statistics_modes = compute_statistics_modes(args.statistics)
+    channel_targets: List[channel.ChannelTarget] = []
+    if args.scope == "all":
+        if statistics_modes != ["post"]:
+            raise ValueError("--scope all currently supports only post statistics")
+        channel_targets = channel.discover_resnet_targets(
+            base_bundle.model, base_bundle.classifier_name
+        )
 
     for method in args.methods:
         print(f"[NeuronRank] Computing scores with method={method}…", flush=True)
         score_time_start = time.time()
         if device.type == "cuda":
             torch.cuda.reset_peak_memory_stats(device)
-        score_tensors = compute_scores(method, statistics_modes, base_bundle, loaders, device, args)
+        if args.scope == "fc":
+            score_tensors = compute_classifier_scores(
+                method, statistics_modes, base_bundle, loaders, device, args
+            )
+        else:
+            score_tensors = {
+                "post": compute_channel_scores(
+                    method, base_bundle, channel_targets, loaders, device, args
+                )
+            }
         score_time = time.time() - score_time_start
         peak_mem = (
             torch.cuda.max_memory_allocated(device) / 1024**2 if device.type == "cuda" else 0.0
         )
 
         for stats_mode, scores in score_tensors.items():
-            for sparsity in args.sparsities:
-                print(
-                    f"[NeuronRank] Evaluating sparsity={sparsity:.2f} ({stats_mode})",
-                    flush=True,
-                )
-                keep_indices = mask.build_keep_indices(scores, sparsity)
-                pruned_bundle = mask.apply_pruning(base_bundle, keep_indices)
-                pruned_bundle.model.to(device)
+            if args.scope == "fc":
+                for sparsity in args.sparsities:
+                    print(
+                        f"[NeuronRank] Evaluating sparsity={sparsity:.2f} ({stats_mode})",
+                        flush=True,
+                    )
+                    keep_indices = mask.build_keep_indices(scores, sparsity)
+                    pruned_bundle = mask.apply_pruning(base_bundle, keep_indices)
+                    pruned_bundle.model.to(device)
 
-                kept_params = mask.count_parameters(pruned_bundle.model)
-                zero_acc, eval_time = evaluate_model(pruned_bundle, loaders.eval, device)
+                    kept_params = mask.count_parameters(pruned_bundle.model)
+                    zero_acc, eval_time = evaluate_model(pruned_bundle, loaders.eval, device)
 
-                ft_acc, ft_total_time, ft_epoch_avg = finetune(
-                    pruned_bundle,
-                    loaders,
-                    device,
-                    args.recover_epochs,
-                    args.lr,
-                    args.weight_decay,
-                    args.momentum,
-                    args.amp,
-                    args.log_interval,
-                )
+                    timestamp = datetime.utcnow().isoformat()
+                    row_data = dict(
+                        timestamp=timestamp,
+                        seed=seed,
+                        device=str(device),
+                        dataset=args.dataset,
+                        hf_model_id=args.hf_model_id,
+                        layer=base_bundle.classifier_name,
+                        method=method,
+                        statistics=stats_mode,
+                        sparsity=sparsity,
+                        kept_params=kept_params,
+                        zero_shot_acc_top1=zero_acc,
+                        zero_shot_eval_time_s=eval_time,
+                        score_time_s=score_time,
+                        score_peak_mem_mb=peak_mem,
+                        ft_epochs=0,
+                        ft_epoch_time_avg_s=0.0,
+                        ft_total_time_s=0.0,
+                        ft_acc_top1=float("nan"),
+                        notes=args.notes,
+                    )
+                    logger.log(MetricRow(**row_data))
 
-                timestamp = datetime.utcnow().isoformat()
-                row = MetricRow(
-                    timestamp=timestamp,
-                    seed=seed,
-                    device=str(device),
-                    dataset=args.dataset,
-                    hf_model_id=args.hf_model_id,
-                    layer=base_bundle.classifier_name,
-                    method=method,
-                    statistics=stats_mode,
-                    sparsity=sparsity,
-                    kept_params=kept_params,
-                    zero_shot_acc_top1=zero_acc,
-                    zero_shot_eval_time_s=eval_time,
-                    score_time_s=score_time,
-                    score_peak_mem_mb=peak_mem,
-                    ft_epochs=args.recover_epochs,
-                    ft_epoch_time_avg_s=ft_epoch_avg,
-                    ft_total_time_s=ft_total_time,
-                    ft_acc_top1=ft_acc,
-                    notes=args.notes,
-                )
-                logger.log(row)
-                print(
-                    f"[NeuronRank] Logged results | method={method} | stats={stats_mode} | sparsity={sparsity:.2f}",
-                    flush=True,
-                )
+                    if args.recover_epochs > 0:
+                        ft_acc, ft_total_time, ft_epoch_avg = finetune(
+                            pruned_bundle,
+                            loaders,
+                            device,
+                            args.recover_epochs,
+                            args.lr,
+                            args.weight_decay,
+                            args.momentum,
+                            args.amp,
+                            args.log_interval,
+                        )
+                        row_data.update(
+                            ft_epochs=args.recover_epochs,
+                            ft_acc_top1=ft_acc,
+                            ft_total_time_s=ft_total_time,
+                            ft_epoch_time_avg_s=ft_epoch_avg,
+                        )
+                        logger.log(MetricRow(**row_data))
+                    print(
+                        f"[NeuronRank] Logged results | method={method} | stats={stats_mode} | sparsity={sparsity:.2f}",
+                        flush=True,
+                    )
+            else:
+                for target in channel_targets:
+                    layer_scores = scores[target.name]
+                    for sparsity in args.sparsities:
+                        effective = min(sparsity, target.max_sparsity)
+                        print(
+                            "[NeuronRank] Evaluating layer={} sparsity={:.2f} ({})".format(
+                                target.name, effective, method
+                            ),
+                            flush=True,
+                        )
+                        keep_indices = channel.plan_layer_keep_indices(
+                            layer_scores, sparsity, target.max_sparsity
+                        )
+                        pruned_bundle, kept_params = channel.apply_structured_pruning(
+                            base_bundle, target, keep_indices
+                        )
+                        pruned_bundle.model.to(device)
+
+                        zero_acc, eval_time = evaluate_model(pruned_bundle, loaders.eval, device)
+
+                        timestamp = datetime.utcnow().isoformat()
+                        row_data = dict(
+                            timestamp=timestamp,
+                            seed=seed,
+                            device=str(device),
+                            dataset=args.dataset,
+                            hf_model_id=args.hf_model_id,
+                            layer=target.name,
+                            method=method,
+                            statistics=stats_mode,
+                            sparsity=effective,
+                            kept_params=kept_params,
+                            zero_shot_acc_top1=zero_acc,
+                            zero_shot_eval_time_s=eval_time,
+                            score_time_s=score_time,
+                            score_peak_mem_mb=peak_mem,
+                            ft_epochs=0,
+                            ft_epoch_time_avg_s=0.0,
+                            ft_total_time_s=0.0,
+                            ft_acc_top1=float("nan"),
+                            notes=args.notes,
+                        )
+                        logger.log(MetricRow(**row_data))
+
+                        if args.recover_epochs > 0:
+                            ft_acc, ft_total_time, ft_epoch_avg = finetune(
+                                pruned_bundle,
+                                loaders,
+                                device,
+                                args.recover_epochs,
+                                args.lr,
+                                args.weight_decay,
+                                args.momentum,
+                                args.amp,
+                                args.log_interval,
+                            )
+                            row_data.update(
+                                ft_epochs=args.recover_epochs,
+                                ft_acc_top1=ft_acc,
+                                ft_total_time_s=ft_total_time,
+                                ft_epoch_time_avg_s=ft_epoch_avg,
+                            )
+                            logger.log(MetricRow(**row_data))
+                        print(
+                            "[NeuronRank] Logged results | method={} | layer={} | sparsity={:.2f}".format(
+                                method, target.name, effective
+                            ),
+                            flush=True,
+                        )
 
 
 def main() -> None:

--- a/NeuronRank/neronrank/pruning/__init__.py
+++ b/NeuronRank/neronrank/pruning/__init__.py
@@ -1,5 +1,5 @@
 """Pruning utilities exposed for convenience."""
 
-from . import hooks, mask, scoring, surgery
+from . import channel, hooks, mask, scoring, surgery
 
-__all__ = ["hooks", "mask", "scoring", "surgery"]
+__all__ = ["channel", "hooks", "mask", "scoring", "surgery"]

--- a/NeuronRank/neronrank/pruning/channel.py
+++ b/NeuronRank/neronrank/pruning/channel.py
@@ -1,0 +1,409 @@
+"""Structured channel pruning utilities for convolutional backbones."""
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import torch
+import torch.nn as nn
+
+from ..models.resnet_loader import ModelBundle
+from .mask import build_keep_indices, count_parameters
+
+
+@dataclass
+class ChannelTarget:
+    """Description of a convolutional block output eligible for pruning."""
+
+    name: str
+    conv: str
+    bn: str
+    activation: str
+    next_conv: Optional[str]
+    downsample_conv: Optional[str]
+    downsample_bn: Optional[str]
+    max_sparsity: float
+    out_channels: int
+
+
+def _get_module(root: nn.Module, name: str) -> nn.Module:
+    module: nn.Module = root
+    if name == "":
+        return module
+    for part in name.split("."):
+        module = module[int(part)] if part.isdigit() else getattr(module, part)
+    return module
+
+
+def _set_module(root: nn.Module, name: str, new_module: nn.Module) -> None:
+    parts = name.split(".")
+    parent = root
+    for part in parts[:-1]:
+        parent = parent[int(part)] if part.isdigit() else getattr(parent, part)
+    last = parts[-1]
+    if last.isdigit():
+        parent[int(last)] = new_module
+    else:
+        setattr(parent, last, new_module)
+
+
+def _stage_max_sparsity(stage: int) -> float:
+    if stage <= 0:
+        return 0.5
+    if stage == 1:
+        return 0.5
+    if stage == 2:
+        return 0.7
+    if stage == 3:
+        return 0.9
+    return 0.95
+
+
+def discover_resnet_targets(model: nn.Module, classifier_name: str) -> List[ChannelTarget]:
+    """Collect convolutional outputs that can be pruned in a ResNet."""
+
+    targets: List[ChannelTarget] = []
+
+    if hasattr(model, "conv1") and hasattr(model, "bn1"):
+        stem_conv: nn.Conv2d = getattr(model, "conv1")
+        out_channels = stem_conv.out_channels
+        next_conv: Optional[str] = None
+        if hasattr(model, "layer1") and len(getattr(model, "layer1")) > 0:
+            next_conv = "layer1.0.conv1"
+        target = ChannelTarget(
+            name="stem",
+            conv="conv1",
+            bn="bn1",
+            activation="relu" if hasattr(model, "relu") else "",
+            next_conv=next_conv,
+            downsample_conv=None,
+            downsample_bn=None,
+            max_sparsity=_stage_max_sparsity(0),
+            out_channels=out_channels,
+        )
+        targets.append(target)
+
+    for stage in range(1, 5):
+        layer_name = f"layer{stage}"
+        if not hasattr(model, layer_name):
+            continue
+        layer = getattr(model, layer_name)
+        blocks: Sequence[nn.Module] = list(layer)
+        if not blocks:
+            continue
+        for block_idx, block in enumerate(blocks):
+            prefix = f"{layer_name}.{block_idx}"
+            if not hasattr(block, "conv2") or not hasattr(block, "bn2"):
+                continue
+            conv2: nn.Conv2d = getattr(block, "conv2")
+            out_channels = conv2.out_channels
+            next_conv: Optional[str] = None
+            if block_idx + 1 < len(blocks):
+                next_conv = f"{layer_name}.{block_idx + 1}.conv1"
+            else:
+                for next_stage in range(stage + 1, 5):
+                    next_layer_name = f"layer{next_stage}"
+                    if hasattr(model, next_layer_name):
+                        next_layer = getattr(model, next_layer_name)
+                        if len(next_layer) > 0:
+                            next_conv = f"{next_layer_name}.0.conv1"
+                            break
+                if next_conv is None:
+                    next_conv = classifier_name
+
+            downsample_conv: Optional[str] = None
+            downsample_bn: Optional[str] = None
+            if getattr(block, "downsample", None) is not None:
+                downsample = block.downsample
+                if len(downsample) > 0 and isinstance(downsample[0], nn.Conv2d):
+                    downsample_conv = f"{prefix}.downsample.0"
+                if len(downsample) > 1 and isinstance(downsample[1], nn.BatchNorm2d):
+                    downsample_bn = f"{prefix}.downsample.1"
+
+            targets.append(
+                ChannelTarget(
+                    name=prefix,
+                    conv=f"{prefix}.conv2",
+                    bn=f"{prefix}.bn2",
+                    activation=prefix,
+                    next_conv=next_conv,
+                    downsample_conv=downsample_conv,
+                    downsample_bn=downsample_bn,
+                    max_sparsity=_stage_max_sparsity(stage),
+                    out_channels=out_channels,
+                )
+            )
+
+    return targets
+
+
+def _prepare_storage(targets: Iterable[ChannelTarget]) -> Dict[str, Dict[str, torch.Tensor]]:
+    storage: Dict[str, Dict[str, torch.Tensor]] = {}
+    for target in targets:
+        storage[target.name] = {
+            "tf_sum": torch.zeros(target.out_channels),
+            "df": torch.zeros(target.out_channels),
+            "count": torch.tensor(0.0),
+        }
+    return storage
+
+
+def collect_post_activation_stats(
+    model: nn.Module,
+    targets: Sequence[ChannelTarget],
+    dataloader,
+    device: torch.device,
+    limit: Optional[int] = None,
+    threshold: float = 1e-6,
+) -> Dict[str, Dict[str, torch.Tensor]]:
+    """Collect per-channel activation statistics after ReLU."""
+
+    storage = _prepare_storage(targets)
+
+    handles = []
+
+    for target in targets:
+        module = _get_module(model, target.activation)
+
+        def hook(_module, _inputs, outputs, *, name=target.name):
+            if isinstance(outputs, tuple):
+                tensor = outputs[0]
+            else:
+                tensor = outputs
+            if tensor.dim() != 4:
+                raise RuntimeError("Expected convolutional activation with 4 dimensions")
+            tensor = tensor.detach().cpu()
+            mean_hw = tensor.abs().mean(dim=(2, 3))
+            storage[name]["tf_sum"] += mean_hw.sum(dim=0)
+            storage[name]["df"] += (mean_hw > threshold).sum(dim=0)
+            storage[name]["count"] += float(mean_hw.shape[0])
+
+        handles.append(module.register_forward_hook(hook))
+
+    model.eval()
+    processed = 0
+    with torch.no_grad():
+        for batch in dataloader:
+            inputs, _ = batch
+            inputs = inputs.to(device)
+            model(inputs)
+            processed += inputs.size(0)
+            if limit is not None and processed >= limit:
+                break
+
+    for handle in handles:
+        handle.remove()
+
+    for target in targets:
+        entry = storage[target.name]
+        total = entry["count"].clamp_min(1.0)
+        entry["tf"] = entry["tf_sum"] / total
+        entry["N"] = total
+
+    return storage
+
+
+def compute_magnitude_scores(
+    model: nn.Module, targets: Sequence[ChannelTarget]
+) -> Dict[str, torch.Tensor]:
+    scores: Dict[str, torch.Tensor] = {}
+    for target in targets:
+        conv: nn.Conv2d = _get_module(model, target.conv)  # type: ignore[assignment]
+        weight = conv.weight.detach().abs().view(conv.out_channels, -1)
+        scores[target.name] = weight.sum(dim=1).cpu()
+    return scores
+
+
+def compute_neuronrank_scores(
+    model: nn.Module,
+    targets: Sequence[ChannelTarget],
+    dataloader,
+    device: torch.device,
+    alpha: float,
+    beta: float,
+    gamma: float,
+    limit: Optional[int] = None,
+) -> Dict[str, torch.Tensor]:
+    stats = collect_post_activation_stats(model, targets, dataloader, device, limit)
+    base = compute_magnitude_scores(model, targets)
+    scores: Dict[str, torch.Tensor] = {}
+    for target in targets:
+        entry = stats[target.name]
+        tf = entry["tf"]
+        df = entry["df"].clamp_min(0.0)
+        total = entry["N"].item()
+        idf = torch.log((total + 1.0) / (df + 1.0))
+        scores[target.name] = (base[target.name] ** alpha) * (tf ** beta) * (idf ** gamma)
+    return scores
+
+
+def compute_first_order_scores(
+    model: nn.Module,
+    targets: Sequence[ChannelTarget],
+    dataloader,
+    device: torch.device,
+    limit: Optional[int] = None,
+) -> Dict[str, torch.Tensor]:
+    criterion = nn.CrossEntropyLoss()
+    grads: Dict[str, torch.Tensor] = {
+        target.name: torch.zeros(target.out_channels, device=device) for target in targets
+    }
+
+    processed = 0
+    was_training = model.training
+    model.train()
+    for inputs, labels in dataloader:
+        inputs = inputs.to(device)
+        labels = labels.to(device)
+        model.zero_grad(set_to_none=True)
+        outputs = model(inputs)
+        if isinstance(outputs, dict):
+            logits = outputs["logits"]
+        elif hasattr(outputs, "logits"):
+            logits = outputs.logits
+        else:
+            logits = outputs
+        loss = criterion(logits, labels)
+        loss.backward()
+        for target in targets:
+            conv: nn.Conv2d = _get_module(model, target.conv)  # type: ignore[assignment]
+            if conv.weight.grad is None:
+                continue
+            score = (conv.weight.grad * conv.weight).abs().view(conv.out_channels, -1).sum(dim=1)
+            grads[target.name] += score.detach()
+        processed += inputs.size(0)
+        if limit is not None and processed >= limit:
+            break
+
+    if was_training is False:
+        model.eval()
+
+    return {name: tensor.detach().cpu() for name, tensor in grads.items()}
+
+
+def _slice_conv_out(conv: nn.Conv2d, keep: torch.Tensor) -> nn.Conv2d:
+    new_conv = nn.Conv2d(
+        in_channels=conv.in_channels,
+        out_channels=len(keep),
+        kernel_size=conv.kernel_size,
+        stride=conv.stride,
+        padding=conv.padding,
+        dilation=conv.dilation,
+        groups=conv.groups,
+        bias=conv.bias is not None,
+        padding_mode=conv.padding_mode,
+    )
+    new_conv.weight.data.copy_(conv.weight.detach()[keep].clone())
+    if conv.bias is not None and new_conv.bias is not None:
+        new_conv.bias.data.copy_(conv.bias.detach()[keep].clone())
+    return new_conv
+
+
+def _slice_conv_in(conv: nn.Conv2d, keep: torch.Tensor) -> nn.Conv2d:
+    new_conv = nn.Conv2d(
+        in_channels=len(keep),
+        out_channels=conv.out_channels,
+        kernel_size=conv.kernel_size,
+        stride=conv.stride,
+        padding=conv.padding,
+        dilation=conv.dilation,
+        groups=conv.groups,
+        bias=conv.bias is not None,
+        padding_mode=conv.padding_mode,
+    )
+    new_conv.weight.data.copy_(conv.weight.detach()[:, keep].clone())
+    if conv.bias is not None and new_conv.bias is not None:
+        new_conv.bias.data.copy_(conv.bias.detach().clone())
+    return new_conv
+
+
+def _slice_batchnorm(bn: nn.BatchNorm2d, keep: torch.Tensor) -> nn.BatchNorm2d:
+    new_bn = nn.BatchNorm2d(
+        num_features=len(keep),
+        eps=bn.eps,
+        momentum=bn.momentum,
+        affine=bn.affine,
+        track_running_stats=bn.track_running_stats,
+    )
+    if bn.affine:
+        new_bn.weight.data.copy_(bn.weight.detach()[keep].clone())
+        new_bn.bias.data.copy_(bn.bias.detach()[keep].clone())
+    if bn.track_running_stats:
+        new_bn.running_mean.data.copy_(bn.running_mean.detach()[keep].clone())
+        new_bn.running_var.data.copy_(bn.running_var.detach()[keep].clone())
+        new_bn.num_batches_tracked.data.copy_(bn.num_batches_tracked.detach())
+    return new_bn
+
+
+def _slice_linear_in(linear: nn.Linear, keep: torch.Tensor) -> nn.Linear:
+    new_linear = nn.Linear(
+        in_features=len(keep),
+        out_features=linear.out_features,
+        bias=linear.bias is not None,
+    )
+    new_linear.weight.data.copy_(linear.weight.detach()[:, keep].clone())
+    if linear.bias is not None and new_linear.bias is not None:
+        new_linear.bias.data.copy_(linear.bias.detach().clone())
+    return new_linear
+
+
+def apply_structured_pruning(
+    bundle: ModelBundle,
+    target: ChannelTarget,
+    keep_indices: Sequence[int],
+) -> Tuple[ModelBundle, int]:
+    """Apply structured channel pruning for a single target."""
+
+    new_model = copy.deepcopy(bundle.model)
+    keep = torch.tensor(sorted(keep_indices), dtype=torch.long)
+
+    conv: nn.Conv2d = _get_module(new_model, target.conv)  # type: ignore[assignment]
+    pruned_conv = _slice_conv_out(conv, keep)
+    _set_module(new_model, target.conv, pruned_conv)
+
+    bn: nn.BatchNorm2d = _get_module(new_model, target.bn)  # type: ignore[assignment]
+    pruned_bn = _slice_batchnorm(bn, keep)
+    _set_module(new_model, target.bn, pruned_bn)
+
+    if target.downsample_conv is not None:
+        down_conv: nn.Conv2d = _get_module(new_model, target.downsample_conv)  # type: ignore[assignment]
+        pruned_down_conv = _slice_conv_out(down_conv, keep)
+        _set_module(new_model, target.downsample_conv, pruned_down_conv)
+    if target.downsample_bn is not None:
+        down_bn: nn.BatchNorm2d = _get_module(new_model, target.downsample_bn)  # type: ignore[assignment]
+        pruned_down_bn = _slice_batchnorm(down_bn, keep)
+        _set_module(new_model, target.downsample_bn, pruned_down_bn)
+
+    classifier_name = bundle.classifier_name
+    feature_dim = bundle.feature_dim
+
+    if target.next_conv is not None:
+        if target.next_conv == classifier_name:
+            linear: nn.Linear = _get_module(new_model, classifier_name)  # type: ignore[assignment]
+            pruned_linear = _slice_linear_in(linear, keep)
+            _set_module(new_model, classifier_name, pruned_linear)
+            feature_dim = pruned_linear.in_features
+        else:
+            next_module = _get_module(new_model, target.next_conv)
+            if isinstance(next_module, nn.Conv2d):
+                pruned_next = _slice_conv_in(next_module, keep)
+                _set_module(new_model, target.next_conv, pruned_next)
+
+    new_bundle = ModelBundle(
+        model=new_model,
+        classifier=_get_module(new_model, classifier_name),  # type: ignore[assignment]
+        classifier_name=classifier_name,
+        feature_dim=feature_dim,
+    )
+    kept_params = count_parameters(new_bundle.model)
+    return new_bundle, kept_params
+
+
+def plan_layer_keep_indices(
+    scores: torch.Tensor,
+    sparsity: float,
+    max_sparsity: float,
+) -> List[int]:
+    effective = min(sparsity, max_sparsity)
+    return build_keep_indices(scores, effective)

--- a/NeuronRank/neronrank/pruning/scoring.py
+++ b/NeuronRank/neronrank/pruning/scoring.py
@@ -53,6 +53,9 @@ def _project_post_activations(
     if acts.dim() != 2:
         acts = acts.flatten(start_dim=1)
 
+    if weight_abs.device != acts.device:
+        weight_abs = weight_abs.to(acts.device)
+
     out_features, in_features = weight_abs.shape
     if acts.shape[1] != out_features:
         raise RuntimeError(
@@ -91,6 +94,9 @@ def neuronrank_scores(
         weight_mag["post"] = magnitude_scores(linear, mode="post")
 
     scores: ScoreDict = {}
+
+    if "post" in activations:
+        weight_abs = linear.weight.detach().abs()
 
     for key, acts in activations.items():
         if key == "post":


### PR DESCRIPTION
## Summary
- add a --scope flag that enables structured ResNet channel pruning when set to all
- discover convolutional block targets and collect per-channel activations for NR/FO scoring
- slice convolution, batch-norm, residual, and classifier weights to prune channels safely and log per-layer metrics

## Testing
- `python -m compileall NeuronRank/neronrank`


------
https://chatgpt.com/codex/tasks/task_e_68d517f03e3c8321a65cb0aefb14611e