### PR TITLE
Handle scope all statistics override

### DIFF
--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -296,7 +296,12 @@ def run(args: argparse.Namespace) -> None:
     channel_targets: List[channel.ChannelTarget] = []
     if args.scope == "all":
         if statistics_modes != ["post"]:
-            raise ValueError("--scope all currently supports only post statistics")
+            print(
+                "[NeuronRank] Warning: --scope all supports only post statistics; "
+                "overriding --statistics to 'post'",
+                flush=True,
+            )
+            statistics_modes = ["post"]
         channel_targets = channel.discover_resnet_targets(
             base_bundle.model, base_bundle.classifier_name
         )


### PR DESCRIPTION
## Summary
- prevent the CLI from aborting when `--scope all` is combined with non-post statistics
- log a warning and automatically force the statistics mode to `post` in that case

## Testing
- python -m compileall neronrank/cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d57fc6ea8c832189bc1b9d7b90f696