### PR TITLE
Fix channel pruning statistics handling and residual alignment

### DIFF
--- a/NeuronRank/neronrank/cli.py
+++ b/NeuronRank/neronrank/cli.py
@@ -211,34 +211,53 @@ def compute_classifier_scores(
 
 def compute_channel_scores(
     method: str,
+    statistics_modes: Sequence[str],
     base_bundle: ModelBundle,
     targets: Sequence[channel.ChannelTarget],
     loaders: DatasetBundle,
     device: torch.device,
     args: argparse.Namespace,
-) -> Dict[str, torch.Tensor]:
+) -> Dict[str, Dict[str, torch.Tensor]]:
     method = method.upper()
+    results: Dict[str, Dict[str, torch.Tensor]] = {}
+
     if method == "MB":
-        return channel.compute_magnitude_scores(base_bundle.model, targets)
+        base_scores = channel.compute_magnitude_scores(base_bundle.model, targets)
+        for mode in statistics_modes:
+            results[mode] = {name: tensor.clone() for name, tensor in base_scores.items()}
+        return results
+
     if method == "NR":
-        return channel.compute_neuronrank_scores(
+        raw_mode = "all" if len(statistics_modes) > 1 else statistics_modes[0]
+        stats_mode = cast(StatisticsMode, raw_mode)
+        nr_scores = channel.compute_neuronrank_scores(
             base_bundle.model,
             targets,
             loaders.calibration,
             device,
+            stats_mode,
             alpha=args.tfidf_alpha,
             beta=args.tfidf_beta,
             gamma=args.tfidf_gamma,
             limit=args.calib_size,
         )
+        for key, value in nr_scores.items():
+            if key in statistics_modes:
+                results[key] = value
+        return results
+
     if method == "FO":
-        return channel.compute_first_order_scores(
+        base_scores = channel.compute_first_order_scores(
             base_bundle.model,
             targets,
             loaders.calibration,
             device,
             limit=args.calib_size,
         )
+        for mode in statistics_modes:
+            results[mode] = {name: tensor.clone() for name, tensor in base_scores.items()}
+        return results
+
     raise ValueError(f"Unknown method: {method}")
 
 
@@ -295,13 +314,6 @@ def run(args: argparse.Namespace) -> None:
     statistics_modes = compute_statistics_modes(args.statistics)
     channel_targets: List[channel.ChannelTarget] = []
     if args.scope == "all":
-        if statistics_modes != ["post"]:
-            print(
-                "[NeuronRank] Warning: --scope all supports only post statistics; "
-                "overriding --statistics to 'post'",
-                flush=True,
-            )
-            statistics_modes = ["post"]
         channel_targets = channel.discover_resnet_targets(
             base_bundle.model, base_bundle.classifier_name
         )
@@ -316,11 +328,9 @@ def run(args: argparse.Namespace) -> None:
                 method, statistics_modes, base_bundle, loaders, device, args
             )
         else:
-            score_tensors = {
-                "post": compute_channel_scores(
-                    method, base_bundle, channel_targets, loaders, device, args
-                )
-            }
+            score_tensors = compute_channel_scores(
+                method, statistics_modes, base_bundle, channel_targets, loaders, device, args
+            )
         score_time = time.time() - score_time_start
         peak_mem = (
             torch.cuda.max_memory_allocated(device) / 1024**2 if device.type == "cuda" else 0.0
@@ -391,11 +401,16 @@ def run(args: argparse.Namespace) -> None:
             else:
                 for target in channel_targets:
                     layer_scores = scores[target.name]
+                    seen_effective: set[float] = set()
                     for sparsity in args.sparsities:
                         effective = min(sparsity, target.max_sparsity)
+                        key = round(effective, 4)
+                        if key in seen_effective:
+                            continue
+                        seen_effective.add(key)
                         print(
-                            "[NeuronRank] Evaluating layer={} sparsity={:.2f} ({})".format(
-                                target.name, effective, method
+                            "[NeuronRank] Evaluating layer={} sparsity={:.2f} ({}|{})".format(
+                                target.name, effective, method, stats_mode
                             ),
                             flush=True,
                         )
@@ -453,8 +468,8 @@ def run(args: argparse.Namespace) -> None:
                             )
                             logger.log(MetricRow(**row_data))
                         print(
-                            "[NeuronRank] Logged results | method={} | layer={} | sparsity={:.2f}".format(
-                                method, target.name, effective
+                            "[NeuronRank] Logged results | method={} | stats={} | layer={} | sparsity={:.2f}".format(
+                                method, stats_mode, target.name, effective
                             ),
                             flush=True,
                         )

--- a/NeuronRank/neronrank/pruning/channel.py
+++ b/NeuronRank/neronrank/pruning/channel.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 
 from ..models.resnet_loader import ModelBundle
+from .hooks import StatisticsMode
 from .mask import build_keep_indices, count_parameters
 
 
@@ -186,37 +187,75 @@ def _prepare_storage(targets: Iterable[ChannelTarget]) -> Dict[str, Dict[str, to
     return storage
 
 
-def collect_post_activation_stats(
+def _activation_hook(
+    storage: Dict[str, Dict[str, torch.Tensor]],
+    name: str,
+    threshold: float,
+):
+    def hook(_module, _inputs, outputs):
+        if isinstance(outputs, tuple):
+            tensor = outputs[0]
+        else:
+            tensor = outputs
+        if tensor.dim() != 4:
+            raise RuntimeError("Expected convolutional activation with 4 dimensions")
+        tensor = tensor.detach().cpu()
+        mean_hw = tensor.abs().mean(dim=(2, 3))
+        storage[name]["tf_sum"] += mean_hw.sum(dim=0)
+        storage[name]["df"] += (mean_hw > threshold).sum(dim=0)
+        storage[name]["count"] += float(mean_hw.shape[0])
+
+    return hook
+
+
+def collect_channel_activation_stats(
     model: nn.Module,
     targets: Sequence[ChannelTarget],
     dataloader,
     device: torch.device,
+    modes: Sequence[str],
     limit: Optional[int] = None,
     threshold: float = 1e-6,
-) -> Dict[str, Dict[str, torch.Tensor]]:
-    """Collect per-channel activation statistics after ReLU."""
+) -> Dict[str, Dict[str, Dict[str, torch.Tensor]]]:
+    """Collect per-channel activation statistics for the requested modes."""
 
-    storage = _prepare_storage(targets)
+    requested = tuple(dict.fromkeys(modes))
+    if not requested:
+        raise ValueError("At least one statistics mode must be requested")
+
+    for mode in requested:
+        if mode not in ("before", "post"):
+            raise ValueError("Unsupported statistics mode for channel pruning")
+
+    storage_by_mode: Dict[str, Dict[str, Dict[str, torch.Tensor]]] = {
+        mode: _prepare_storage(targets) for mode in requested
+    }
 
     handles = []
 
     for target in targets:
-        module = _get_module(model, target.activation)
-
-        def hook(_module, _inputs, outputs, *, name=target.name):
-            if isinstance(outputs, tuple):
-                tensor = outputs[0]
-            else:
-                tensor = outputs
-            if tensor.dim() != 4:
-                raise RuntimeError("Expected convolutional activation with 4 dimensions")
-            tensor = tensor.detach().cpu()
-            mean_hw = tensor.abs().mean(dim=(2, 3))
-            storage[name]["tf_sum"] += mean_hw.sum(dim=0)
-            storage[name]["df"] += (mean_hw > threshold).sum(dim=0)
-            storage[name]["count"] += float(mean_hw.shape[0])
-
-        handles.append(module.register_forward_hook(hook))
+        if "before" in storage_by_mode:
+            if not target.bn:
+                raise RuntimeError(
+                    f"Target '{target.name}' does not define a batch-norm module for 'before' statistics"
+                )
+            module = _get_module(model, target.bn)
+            handles.append(
+                module.register_forward_hook(
+                    _activation_hook(storage_by_mode["before"], target.name, threshold)
+                )
+            )
+        if "post" in storage_by_mode:
+            if not target.activation:
+                raise RuntimeError(
+                    f"Target '{target.name}' does not define an activation module for 'post' statistics"
+                )
+            module = _get_module(model, target.activation)
+            handles.append(
+                module.register_forward_hook(
+                    _activation_hook(storage_by_mode["post"], target.name, threshold)
+                )
+            )
 
     model.eval()
     processed = 0
@@ -232,13 +271,20 @@ def collect_post_activation_stats(
     for handle in handles:
         handle.remove()
 
-    for target in targets:
-        entry = storage[target.name]
-        total = entry["count"].clamp_min(1.0)
-        entry["tf"] = entry["tf_sum"] / total
-        entry["N"] = total
+    results: Dict[str, Dict[str, Dict[str, torch.Tensor]]] = {mode: {} for mode in requested}
+    for mode, storage in storage_by_mode.items():
+        mode_results: Dict[str, Dict[str, torch.Tensor]] = {}
+        for target in targets:
+            entry = storage[target.name]
+            total = entry["count"].clamp_min(1.0)
+            mode_results[target.name] = {
+                "tf": entry["tf_sum"] / total,
+                "df": entry["df"].clone(),
+                "N": total.clone(),
+            }
+        results[mode] = mode_results
 
-    return storage
+    return results
 
 
 def compute_magnitude_scores(
@@ -257,22 +303,35 @@ def compute_neuronrank_scores(
     targets: Sequence[ChannelTarget],
     dataloader,
     device: torch.device,
+    mode: StatisticsMode,
     alpha: float,
     beta: float,
     gamma: float,
     limit: Optional[int] = None,
-) -> Dict[str, torch.Tensor]:
-    stats = collect_post_activation_stats(model, targets, dataloader, device, limit)
+) -> Dict[str, Dict[str, torch.Tensor]]:
+    if mode not in ("before", "post", "all"):
+        raise ValueError("mode must be one of {'before', 'post', 'all'}")
+
+    requested = ("before", "post") if mode == "all" else (mode,)
+    stats = collect_channel_activation_stats(
+        model, targets, dataloader, device, requested, limit
+    )
     base = compute_magnitude_scores(model, targets)
-    scores: Dict[str, torch.Tensor] = {}
-    for target in targets:
-        entry = stats[target.name]
-        tf = entry["tf"]
-        df = entry["df"].clamp_min(0.0)
-        total = entry["N"].item()
-        idf = torch.log((total + 1.0) / (df + 1.0))
-        scores[target.name] = (base[target.name] ** alpha) * (tf ** beta) * (idf ** gamma)
-    return scores
+
+    results: Dict[str, Dict[str, torch.Tensor]] = {}
+    for key in requested:
+        per_target: Dict[str, torch.Tensor] = {}
+        for target in targets:
+            entry = stats[key][target.name]
+            tf = entry["tf"].to(base[target.name].dtype)
+            df = entry["df"].clamp_min(0.0).to(base[target.name].dtype)
+            total = float(entry["N"].item())
+            idf = torch.log((total + 1.0) / (df + 1.0))
+            per_target[target.name] = (
+                (base[target.name] ** alpha) * (tf**beta) * (idf**gamma)
+            ).cpu()
+        results[key] = per_target
+    return results
 
 
 def compute_first_order_scores(
@@ -414,6 +473,21 @@ def _ensure_residual_alignment(
         block.downsample = ChannelPad(keep.tolist(), output_channels)
 
 
+def _align_downsample_input(block: nn.Module, keep: torch.Tensor) -> None:
+    """Slice the residual downsample to accept the pruned identity tensor."""
+
+    downsample = getattr(block, "downsample", None)
+    if downsample is None:
+        return
+
+    if isinstance(downsample, nn.Sequential) and len(downsample) > 0:
+        first = downsample[0]
+        if isinstance(first, nn.Conv2d):
+            downsample[0] = _slice_conv_in(first, keep)
+    elif isinstance(downsample, nn.Conv2d):
+        block.downsample = _slice_conv_in(downsample, keep)
+
+
 def apply_structured_pruning(
     bundle: ModelBundle,
     target: ChannelTarget,
@@ -462,6 +536,7 @@ def apply_structured_pruning(
                     keep,
                     getattr(block, "conv2", next_module).out_channels,
                 )
+                _align_downsample_input(block, keep)
 
     if "." in target.conv:
         block_name = target.conv.rsplit(".", 1)[0]


### PR DESCRIPTION
## Summary
- allow channel pruning experiments to request either `before` or `post` statistics (or both) by generalizing score computation
- collect convolutional activation statistics for both modes and reuse them when computing NeuronRank scores
- fix residual downsample alignment and skip duplicate sparsity evaluations per layer to prevent shape mismatches

## Testing
- python -m compileall neronrank

------
https://chatgpt.com/codex/tasks/task_e_68d588ff478c8321a6040889c28d56e5