### PR TITLE
Fix ChannelFootprint dataclass initialization

### DIFF
--- a/NeuronRank/neuronrank/pruning/channel.py
+++ b/NeuronRank/neuronrank/pruning/channel.py
@@ -66,6 +66,7 @@ class ChannelTarget:
 
 
 
+@dataclass
 class ChannelFootprint:
     """Accounting helper describing parameters controlled by a target."""
 


### PR DESCRIPTION
## Summary
- mark `ChannelFootprint` as a dataclass so it can be instantiated with per-channel and total parameters

## Testing
- `python neuronrank/cli.py --scope all` *(fails: ConnectionError downloading cifar10 due to blocked proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d74d66808321aca9f9af5caab7cd