### PR TITLE
Fix residual alignment for custom downsample modules

### DIFF
--- a/NeuronRank/neuronrank/pruning/channel.py
+++ b/NeuronRank/neuronrank/pruning/channel.py
@@ -66,6 +66,7 @@ class ChannelTarget:
 
 
 
+@dataclass
 class ChannelFootprint:
     """Accounting helper describing parameters controlled by a target."""
 
@@ -511,8 +512,24 @@ def _ensure_residual_alignment(
     if identity_channels is None:
         return
     downsample = getattr(block, "downsample", None)
+
+    if isinstance(downsample, ChannelSelect):
+        if identity_channels == output_channels:
+            block.downsample = None
+        else:
+            block.downsample = ChannelSelect(keep.tolist())
+        return
+
+    if isinstance(downsample, ChannelPad):
+        if identity_channels == output_channels:
+            block.downsample = None
+        else:
+            block.downsample = ChannelPad(keep.tolist(), output_channels)
+        return
+
     if downsample is not None:
-        # Existing downsample will be updated separately when needed.
+        # Existing downsample (e.g. a convolutional projection) will be updated
+        # separately when needed.
         return
     if identity_channels == output_channels:
         return


### PR DESCRIPTION
## Summary
- refresh residual adapters inserted during channel pruning so they stay in sync with the latest keep indices and output widths

## Testing
- `python NeuronRank/neuronrank/cli.py --scope all --methods NR --sparsities 0.8 --statistics before --batch-size 32` *(fails: CIFAR-10 dataset download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d74d66808321aca9f9af5caab7cd